### PR TITLE
Add marcelverdult/imap-spamfilter repository

### DIFF
--- a/repositoryList.json
+++ b/repositoryList.json
@@ -4544,6 +4544,14 @@
         "index": 564
     },
     {
+        "url": "https://github.com/marcelverdult/imap-spamfilter",
+        "profile": "https://forums.unraid.net/profile/163897-verdi/",
+        "bio": "Docker-based IMAP spam filter for any IMAP server that supports IDLE. Per-account IDLE, rspamd Bayes scoring, learns from explicit user moves, never deletes mail. Runs 24/7 unattended on Unraid. Four-container stack: spamfilter (custom Python), rspamd, redis, unbound.",
+        "icon": "https://raw.githubusercontent.com/marcelverdult/imap-spamfilter/main/assets/icon.png",
+        "title": "marcelverdult's Repository",
+        "index": 99999
+    },
+    {
         "url": "https://github.com/Marraz/unraid-templates",
         "profile": "https://forums.unraid.net/profile/127460-marraz/",
         "title": "Marraz' Repository",


### PR DESCRIPTION
Adds a new template repository for imap-spamfilter, a Docker-based IMAP spam filter.

## What it is

Four-container Docker stack that filters spam in any IMAP mailbox that supports IDLE:

- **spamfilter** (custom Python) - one thread per account, IDLE on Inbox, polls Junk, scores via rspamd, moves and learns
- **spamfilter-rspamd** (rspamd/rspamd:latest) - Bayes, RBL, SPF/DKIM/DMARC, neural
- **spamfilter-redis** (redis:8-alpine) - Bayes tokens, rate-limit state, capped at 1 GB with noeviction
- **spamfilter-unbound** (mvance/unbound:latest) - local DNS resolver for RBLs

## Safety properties

- Never deletes mail (IMAP MOVE only; trash retention is the user's mail provider's job)
- Refuses to create core user folders (junk/trash) - operator must enable SPECIAL-USE on server or set explicit names, prevents duplicate hierarchies
- Three modes promoted manually: shadow (log only) -> flag -> move
- Bayes only learns from explicit user moves, never autolearns
- Rate-limited with soft refusal; auto-restarting account threads with exponential backoff
- Auto-detects junk/trash via RFC 6154 SPECIAL-USE

## Repo

- https://github.com/marcelverdult/imap-spamfilter
- MIT license
- Image: ghcr.io/marcelverdult/imap-spamfilter:latest (amd64 + arm64)
- README: https://github.com/marcelverdult/imap-spamfilter#readme
- Bootstrap script for Unraid in unraid/bootstrap.sh
- Four templates at unraid/spamfilter*.xml with TemplateURL set for CA auto-update

Used the middle-of-file insertion point (after MarkusMcNugen) and a high unique index (99999) to minimise merge-conflict surface with other pending Add-Repository PRs.