### PR TITLE
Remove blacklisted entry for mstrhakr's Repository

### DIFF
--- a/statistics.json
+++ b/statistics.json
@@ -1851,11 +1851,6 @@
         "Possible environment variable within extra parameters.  This should be handled via a config element (type=variable)"
       ]
     },
-    "mstrhakr's Repository": {
-      "https://raw.githubusercontent.com/mstrhakr/compose_plugin/main/compose.manager.plg": [
-        "App \"Compose Manager Plus (Beta)\" is blacklisted: Blacklisted application"
-      ]
-    },
     "mtrogman's Repository": {
       "mtrogman/managarr:latest": [
         "App \"managarr\" is blacklisted: No longer available on dockerHub (or private)"


### PR DESCRIPTION
This pull request makes a minor update to the `statistics.json` file, removing the entry for "mstrhakr's Repository" and its associated blacklist message. The blacklist happened because I merged main into dev and didn't fix the link before pushing. I have since fixed this but somehow both main and dev were blacklisted. After I fixed the dev link I expected it to come back like last time, but instead the beta option was missing from CA and the main remained blacklisted.

- Data cleanup:
  * Removed the entry for "mstrhakr's Repository" and its blacklisted application from `statistics.json`.