### PR TITLE
Add CrazyDevil66 repository – BrainCut Blur Service

### DIFF
--- a/repositoryList.json
+++ b/repositoryList.json
@@ -1,5979 +1,5989 @@
 [
-    {
-        "url": "https://github.com/7eventy7/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279422-7eventy7/",
-        "bio": "Developer of open source tools that enhance the self-hosted ecosystem. I build software to fill the gaps I discover in my homelab, focusing on clean interfaces and practical functionality.",
-        "icon": "https://raw.githubusercontent.com/7eventy7/unraid-templates/main/7eventy7/images/avatar.png",
-        "DonateLink": "https://ko-fi.com/7eventy7",
-        "DonateText": "Donations are always appreciated!",
-        "title": "7eventy7's Repository",
-        "index": 0
-    },
-    {
-        "url": "https://github.com/A75G/docker-templates",
-        "profile": "https://forums.unraid.net/profile/92683-a75g/",
-        "bio": "Random guy making templates.",
-        "icon": "https://raw.githubusercontent.com/A75G/docker-templates/master/templates/icons/avatar.png",
-        "DonateLink": "https://buymeacoffee.com/a75g",
-        "DonateText": "If you appreciate my work, donations are greatly appreciated!",
-        "Forum": "https://forums.unraid.net/topic/89502-support-a75g-repo/",
-        "title": "A75G's Repository",
-        "index": 1
-    },
-    {
-        "url": "https://github.com/Abrechen2/docker-templates",
-        "profile": null,
-        "bio": "This repository hosts Unraid Community Apps templates for Abrechen2's self-hosted projects.\n\nCurrently published:\n\n- TravStats \u2014 self-hosted travel logbook for small households and groups (1\u201310 users). It's a logbook, not a live tracker \u2014 you record trips manually, scan a boarding pass, or import an email/PDF; flights now, cruises in v2, hotels and POI on the roadmap. Visualise routes on interactive 2D/3D maps, collect 58 achievements, scan boarding passes (QR/barcode/OCR), import bookings from email and PDF via an optional local Ollama LLM, automated backups with retention, optional WebDAV off-site sync, encrypted API-key storage.\n- travstats-db \u2014 the pre-configured PostgreSQL 15 + PostGIS 3.4 companion database TravStats expects. Ships with the database/user pair already aligned to the TravStats default DATABASE_URL \u2014 only the password needs filling in.\n\nInstall order: travstats-db first, then TravStats. Both containers reach each other through the Unraid host via host.docker.internal, so no custom Docker network is required.\n\nSupport: GitHub issues at https://github.com/Abrechen2/TravStats/issues or the Unraid support thread linked below. README and troubleshooting live in the repository homepage.",
-        "icon": "https://raw.githubusercontent.com/Abrechen2/docker-templates/main/icon.svg",
-        "DonateLink": "https://www.paypal.com/donate?hosted_button_id=HW9MPYVURCT42",
-        "DonateText": "Support TravStats development",
-        "Forum": "https://forums.unraid.net/topic/198320-support-travstats-self-hosted-flight-tracker/",
-        "WebPage": "https://github.com/Abrechen2/docker-templates",
-        "title": "Abrechen2's Repository",
-        "index": 2
-    },
-    {
-        "url": "https://github.com/ArabCoders/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/260951-ac-watchstate/",
-        "bio": "Docker Images Maintainer.",
-        "icon": "https://raw.githubusercontent.com/ArabCoders/unraid-templates/master/arabcoders/images/profile.png",
-        "DonateLink": "https://worldwish.org/",
-        "DonateText": "If you appreciate my work, then please consider donating to children charity.",
-        "title": "AC-WatchState's Repository",
-        "index": 3
-    },
-    {
-        "url": "https://github.com/acidrs03/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125556-acidrs/",
-        "bio": "I love crafting custom game servers that feel like they were built just for you \u2014 from modded Minecraft in Unraid to whatever gaming rabbit hole I fall into next. Always open for requests.",
-        "icon": "https://avatars.githubusercontent.com/u/30998404?v=4",
-        "DonateLink": "https://ko-fi.com/acidrs",
-        "DonateText": "If you\u2019ve found something useful or just enjoy watching my experiments unfold, feel free to toss a coffee my way. I will probably spend it on more tinkering.",
-        "title": "Acidrs' Repository",
-        "index": 4
-    },
-    {
-        "url": "https://github.com/advplyr/docker-templates",
-        "profile": "https://forums.unraid.net/profile/128533-advplyr/",
-        "bio": "Just tinkering around for now.",
-        "icon": "https://github.com/advplyr/docker-templates/raw/master/advplyr_avatar.png",
-        "title": "advplyr's Repository",
-        "index": 5
-    },
-    {
-        "url": "https://github.com/Aerilym/docker-templates",
-        "profile": "https://forums.unraid.net/profile/158147-aerilym/",
-        "bio": "Creating Docker containers to solve my problems and hopefully other people's problems too.",
-        "icon": "https://raw.githubusercontent.com/aerilym/docker-templates/master/aerilym/images/avatar.jpg",
-        "DonateLink": "https://paypal.me/aerilym",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Aerilym's Repository",
-        "index": 6
-    },
-    {
-        "url": "https://github.com/agusalex/docker-templates",
-        "profile": "https://forums.unraid.net/profile/80800-agusalex",
-        "bio": "Creating Unraid Apps for fun",
-        "icon": "https://raw.githubusercontent.com/agusalex/docker-templates/master/agusalex/images/avatar.jpg",
-        "DonateLink": "https://www.paypal.me/AgustinAlexander",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "agusalex' Repository",
-        "index": 7
-    },
-    {
-        "url": "https://github.com/ahmadnassri/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/123283-ahmad/",
-        "bio": "Developer applications, tools and utilities for Unraid",
-        "icon": "https://github.com/ahmadnassri.png",
-        "DonateLink": "https://github.com/sponsors/ahmadnassri",
-        "DonateText": "Buy me a coffee",
-        "title": "Ahmad's Repository",
-        "index": 8
-    },
-    {
-        "url": "https://github.com/alex3305/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/149439-alex3305/",
-        "bio": "Docker expert creating easy-to-use container stacks.",
-        "icon": "https://avatars.githubusercontent.com/u/5155694?v=4.jpg",
-        "title": "alex3305's Repository",
-        "index": 9
-    },
-    {
-        "url": "https://github.com/alex-red/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/160581-alexred/",
-        "bio": "Curating, creating, and contemplating awesome, productive projects.",
-        "icon": "https://github.com/alex-red.png",
-        "DonateLink": "https://ko-fi.com/alexredcode",
-        "DonateText": "Constantly low on coffee =], would appreciate some more.",
-        "title": "AlexRed's Repository",
-        "index": 10
-    },
-    {
-        "url": "https://github.com/alexycodes/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/288438-alexycodes/",
-        "bio": "Software developer specializing in building web applications. Enthusiastic about all things technology, with a special mention for servers and self-hosting.",
-        "icon": "https://raw.githubusercontent.com/alexycodes/alexycodes/refs/heads/main/avatar.svg",
-        "title": "Alexy's Repository",
-        "index": 11
-    },
-    {
-        "url": "https://github.com/Aquillacomputingsystem/unraid-templetes",
-        "profile": "https://forums.unraid.net/profile/86880-alphacosmos/",
-        "bio": "Just creating containers that I need that the CA store doesnt have. Mainly focussing on Media Server, Home Automation and 3d printing/CNC/engineering containers.",
-        "icon": "https://raw.githubusercontent.com/Alphacosmos/unraid-templetes/main/Images/logo.png",
-        "DonateLink": "https://paypal.me/justinkurban",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Alphacosmos' Repository",
-        "index": 12
-    },
-    {
-        "url": "https://github.com/alturismo/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/70845-alturismo/",
-        "bio": "some small dockers related to Multimedia preferences.",
-        "icon": "https://avatars1.githubusercontent.com/u/8406490?s=460&u=99ac623b70da7467b0d6db3bbef771b5680542e2&v=4",
-        "title": "alturismo's Repository",
-        "index": 13
-    },
-    {
-        "url": "https://github.com/am385/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/122712-am385/",
-        "bio": "Unraid Docker Templates maintained by am385.",
-        "icon": "https://raw.githubusercontent.com/am385/unraid-docker-templates/master/am385/images/profile.png",
-        "title": "am385's Repository",
-        "index": 14
-    },
-    {
-        "url": "https://github.com/cross-seed/unraid-template",
-        "profile": "https://forums.unraid.net/profile/243161-ambipro/",
-        "bio": "cross-seed dev, deluge team member, and creator of retraktarr",
-        "icon": "https://i.imgur.com/2icY7tF.png",
-        "DonateLink": "https://tip.ary.dev",
-        "DonateText": "If you appreciate any of my work, please consider buying me a coffee.",
-        "WebPage": "https://git.ary.dev",
-        "title": "ambipro's Repository",
-        "index": 15
-    },
-    {
-        "url": "https://github.com/andaks/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/114400-andaks/",
-        "bio": "Creating docker containers templates that i use.",
-        "icon": "https://avatars.githubusercontent.com/u/5965423",
-        "DonateLink": "https://paypal.me/andakz",
-        "DonateText": "If you like my work please consider Donating.",
-        "Forum": "https://forums.unraid.net/topic/177991-support-andaks-docker-application",
-        "title": "andaks' Repository",
-        "index": 16
-    },
-    {
-        "url": "https://github.com/andrew207/splunk",
-        "profile": "https://forums.unraid.net/profile/77842-andrew207/",
-        "bio": "Containers focused on security. Where possible based on Alpine.",
-        "DonateLink": "https://www.paypal.me/atunnecliffe",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Andrew207's Repository",
-        "index": 17
-    },
-    {
-        "url": "https://github.com/clairekardas/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/269754-anna/",
-        "bio": "literally just a girl. and Unraid user. publishing docker containers that i use.",
-        "icon": "https://github.com/clairekardas/unraid-templates/blob/main/images/profile.png?raw=true",
-        "WebPage": "https://github.com/clairekardas",
-        "title": "anna's Repository",
-        "index": 18
-    },
-    {
-        "url": "https://github.com/apfaffman/docker-templates",
-        "profile": "https://forums.unraid.net/profile/223909-apfaffman/",
-        "bio": "Just trying to spread the Unraid love by creating useful images.",
-        "icon": "https://raw.githubusercontent.com/apfaffman/docker-templates/refs/heads/main/peanut.png",
-        "DonateLink": "https://www.reddit.com/r/ukraine/comments/s6g5un/want_to_support_ukraine_heres_a_list_of_charities",
-        "DonateText": "If you like this, please consider donating to the Ukrainian defense effort.",
-        "title": "apfaffman's Repository",
-        "index": 19
-    },
-    {
-        "url": "https://github.com/rommapp/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279632-arcaneasada/",
-        "bio": "The team behind RomM, the beautiful, powerful, self-hosted rom manager.",
-        "icon": "https://raw.githubusercontent.com/rommapp/romm/master/.github/resources/isotipo.png",
-        "Forum": "https://github.com/rommapp/romm/issues",
-        "Discord": "https://discord.gg/P5HtHnhUDH",
-        "WebPage": "https://opencollective.com/romm",
-        "title": "arcanesada's Repository",
-        "index": 20
-    },
-    {
-        "url": "https://github.com/ArieDed/unraid-template",
-        "profile": "https://forums.unraid.net/profile/119153-arieded/",
-        "bio": "Repository with some templates for useful Docker containers from Dockerhub that I use myself.",
-        "icon": "https://raw.githubusercontent.com/ArieDed/unraid-template/master/img/avatar.jpg",
-        "DonateLink": "https://www.paypal.me/arieded",
-        "DonateText": "Buy me a coffee",
-        "title": "ArieDed's Repository",
-        "index": 21
-    },
-    {
-        "url": "https://github.com/av1155/houndarr-unraid-template",
-        "profile": "https://forums.unraid.net/profile/294737-av1155/",
-        "bio": "Andrea A. Venti Fuentes is an independent software and platform engineer focused on building practical, reliable self-hosted tools and infrastructure.",
-        "icon": "https://avatars.githubusercontent.com/u/117413846?v=4",
-        "WebPage": "https://andreaventi.com",
-        "title": "av1155's Repository",
-        "index": 22
-    },
-    {
-        "url": "https://github.com/TheAxelander/unraid_ca",
-        "profile": "https://forums.unraid.net/profile/117678-axelander/",
-        "bio": "Free time developer of apps mostly based on C# and on personal needs.",
-        "icon": "https://secure.gravatar.com/avatar/1297f1219f717dac0210118c93717ce9",
-        "title": "Axelander's Repository",
-        "index": 23
-    },
-    {
-        "url": "https://github.com/b3rrytech/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/11610-b3rrytech/",
-        "bio": "In the spirit of \"Value for value\" in the self-hosting community I will try to publish easy-to-use Docker templates of useful applications for others to enjoy.\n    All cred to the authors of these images, as I'm no developer myself. Please show your support to them!",
-        "icon": "https://raw.githubusercontent.com/b3rrytech/unraid-docker-templates/main/ca_profile/b3rrytech_avatar.png",
-        "Forum": "https://general-support-url",
-        "title": "b3rrytech's Repository",
-        "index": 24
-    },
-    {
-        "url": "https://github.com/b3rs3rk/gpustat-unraid",
-        "profile": "https://forums.unraid.net/profile/103683-b3rs3rk",
-        "bio": "Author of the GPUStat plugin, and not much else.  Learned to code using PHP, so my work should be suspect at best.",
-        "icon": "https://avatars2.githubusercontent.com/u/3584954?s=460&u=e047c1e6439bb6c4e138d8fe1d377f346e806b78",
-        "DonateLink": "http://www.whippingchildhoodcancer.org/get-involved.html",
-        "DonateText": "If you enjoy my work and want to donate, please make one to Whipping Childhood Cancer.  Thanks!",
-        "title": "b3rs3rk's Repository",
-        "index": 25
-    },
-    {
-        "url": "https://github.com/balloob/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/62499-balloob/",
-        "bio": "Founder Home Assistant",
-        "icon": "https://github.com/balloob.png",
-        "DonateLink": "https://github.com/sponsors/balloob/",
-        "DonateText": "Fund the development of Home Assistant",
-        "title": "Balloob's Repository",
-        "index": 26
-    },
-    {
-        "url": "https://github.com/Balya/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/166805-balya/",
-        "bio": "I'm trying to support the community and create configurations for those applications that are not yet in the catalog.",
-        "icon": "https://avatars.githubusercontent.com/u/3105824?v=4",
-        "DonateLink": "https://qiwi.com/n/BALYA",
-        "DonateText": "If you like my work please consider Donating.",
-        "Facebook": "https://www.facebook.com/alexander.balya/",
-        "Twitter": "https://twitter.com/Balya",
-        "Discord": "https://discord.com/users/7817",
-        "title": "Balya's Repository",
-        "index": 27
-    },
-    {
-        "url": "https://github.com/miketweaver/docker-templates",
-        "profile": "https://forums.unraid.net/profile/69309-bashninja/",
-        "bio": "Creating Docker containers for myself and sharing with the world. I base most of my images on the LinuxServer.io system.",
-        "icon": "https://raw.githubusercontent.com/miketweaver/docker-templates/master/bashninja/bashninja.png",
-        "Forum": "https://forums.unraid.net/topic/46664-support-bashninja-dockers-starbound-pritunl-demonsaw-etc/",
-        "title": "bashNinja's Repository",
-        "index": 28
-    },
-    {
-        "url": "https://github.com/greycubesgav/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119829-beastieg/",
-        "bio": "Docker applications for Unraid. Includes cryptomator-webdav",
-        "icon": "https://avatars.githubusercontent.com/u/3426859?v=4",
-        "title": "beastieg's Repository",
-        "index": 29
-    },
-    {
-        "url": "https://github.com/BGameiro2000/unraid-ca",
-        "profile": "https://forums.unraid.net/profile/110702-bgameiro/",
-        "bio": "Undergraduate Physicist Student and hobbyist self-hoster. Repository with some templates for applications that I use myself.",
-        "icon": "https://bgameiro.gitlab.io/cv/profile.jpeg",
-        "DonateLink": "https://bgameiro.me/page/donate",
-        "DonateText": "If you like my work please consider Donating.",
-        "Forum": "https://forums.unraid.net/topic/94979-trilium-docker/",
-        "WebPage": "https://bgameiro.me/",
-        "title": "BGameiro's Repository",
-        "index": 30
-    },
-    {
-        "url": "https://github.com/binhex/templates",
-        "profile": "https://forums.unraid.net/profile/11148-binhex/",
-        "bio": "Producing Docker Images with Arch Linux base OS, the main philosophy here is to produce Docker Images that are up to date with the latest stable release (no beta's where possible) to minimize any coding related issues.",
-        "icon": "https://raw.githubusercontent.com/binhex/templates/main/unraid/ca_profile.jpg",
-        "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MM5E27UX6AUU4",
-        "DonateText": "If you appreciate my work, then please consider buying me a beer :D",
-        "title": "Binhex's Repository",
-        "index": 31
-    },
-    {
-        "url": "https://github.com/bitcryptic-gw/unraid-templates",
-        "profile": null,
-        "bio": "Self-hosted AI infrastructure, crypto/DePIN, and Docker templates for Unraid. Building NanoClaw (AI agent platform), ckpool-solo (Bitcoin solo mining), and BitCryptic Compute (crypto-native AI inference). Based in Sydney, Australia.",
-        "icon": "https://raw.githubusercontent.com/bitcryptic-gw/unraid-templates/main/icon.png",
-        "Twitter": "https://twitter.com/BitCrypticGW",
-        "WebPage": "https://bitcryptic.com",
-        "title": "BitCryptic's 2nd Repository",
-        "index": 32
-    },
-    {
-        "url": "https://github.com/bjonness406/Docker-templates",
-        "profile": "https://forums.unraid.net/profile/68356-bjonness406/",
-        "bio": "Making some docker templates",
-        "Forum": "https://forums.unraid.net/topic/47092-support-bjonness406s-repo/",
-        "title": "Bjonness406's Repository",
-        "index": 33
-    },
-    {
-        "url": "https://github.com/BoKKeR/RSSTT-Unraid",
-        "profile": "https://forums.unraid.net/profile/94594-bokker",
-        "bio": "Full time developer publishing mostly my own creations.",
-        "icon": "https://raw.githubusercontent.com/BoKKeR/RSSTT-Unraid/master/images/avatar.jpeg",
-        "DonateLink": "https://www.buymeacoffee.com/bokker",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "BoKKeR's Repository",
-        "index": 34
-    },
-    {
-        "url": "https://github.com/brockbreacher/join-bot-unraid",
-        "profile": "https://forums.unraid.net/profile/171183-brockbreacher/",
-        "bio": "Just a dummy with internet access.",
-        "icon": "https://brbr.xyz/wp-content/uploads/2020/06/e227d6cd-704a-4227-a35c-cbb003c67d55.jpg",
-        "DonateLink": "https://brbr.xyz/donate",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "brockbreacher's Repository",
-        "index": 35
-    },
-    {
-        "url": "https://github.com/cleao01/UnraidDockerTemplates",
-        "profile": "https://forums.unraid.net/profile/123530-cab%C3%A9/",
-        "bio": "Developing for pleasure",
-        "icon": "https://avatars.githubusercontent.com/u/47321842?s=96&v=4",
-        "title": "Cab\u00e9's Repository",
-        "index": 36
-    },
-    {
-        "url": "https://github.com/carroarmato0/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169872-carroarmato0/",
-        "bio": "Open-Source Linux consultant and Unraid enthousiast.",
-        "icon": "https://avatars.githubusercontent.com/u/1828645?v=4",
-        "DonateLink": "https://github.com/sponsors/carroarmato0",
-        "DonateText": "If you find this usefull, feel free to send a small donation (Paypal, Ko_fi or Lightning).",
-        "WebPage": "https://github.com/carroarmato0",
-        "title": "carroarmato0's Repository",
-        "index": 37
-    },
-    {
-        "url": "https://github.com/ccmpbll/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/5869-ccmpbll/",
-        "bio": "Not a developer. Learning stuff and making things.",
-        "icon": "https://raw.githubusercontent.com/ccmpbll/unraid-docker-templates/main/images/avatar.png",
-        "title": "ccmpbll's Repository",
-        "index": 38
-    },
-    {
-        "url": "https://github.com/rufuswilson/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/130601-cedev/",
-        "bio": "Creating containers",
-        "icon": "https://avatars.githubusercontent.com/u/1152051?s=400&v=4",
-        "DonateLink": "https://paypal.me/cdevivier",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "cedev's Repository",
-        "index": 39
-    },
-    {
-        "url": "https://github.com/celsian/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/120837-celsian/",
-        "bio": "Developing small tools to make tedious tasks less difficult.",
-        "icon": "https://raw.githubusercontent.com/celsian/unraid_templates/refs/heads/main/images/avatar.png",
-        "title": "Celsian's Repository",
-        "index": 40
-    },
-    {
-        "url": "https://github.com/RafaelCenzano/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/171730-cenzar/",
-        "bio": "Hosting templates for applications I personally use and things others might find useful. I am also working on developing some self hosted free and open source programs myself.",
-        "icon": "https://raw.githubusercontent.com/RafaelCenzano/unraid-templates/refs/heads/main/avatar.jpeg",
-        "DonateLink": "https://github.com/sponsors/RafaelCenzano",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "cenzar's Repository",
-        "index": 41
-    },
-    {
-        "url": "https://github.com/BB-BenBridges/docker-templates",
-        "profile": "https://forums.unraid.net/profile/70291-cheesemarathon/",
-        "bio": "Making awesome applications easy to install on the best NAS software, Unraid.",
-        "icon": "https://avatars.githubusercontent.com/u/16329132?v=4",
-        "Forum": "https://forums.unraid.net/topic/54183-support-cheesemarathons-repo/",
-        "WebPage": "https://docs.squishedmooo.com",
-        "title": "cheesemarathon's Repository",
-        "index": 42
-    },
-    {
-        "url": "https://github.com/chodeus/unraid-plugins",
-        "profile": null,
-        "bio": "Maintainer of the FolderView3 Plugin for Unraid",
-        "icon": "https://raw.githubusercontent.com/chodeus/unraid-plugins/main/chodeus/servericon.png",
-        "Forum": "https://forums.unraid.net/profile/283711-chodeus/",
-        "title": "chodeus's Repository",
-        "index": 43
-    },
-    {
-        "url": "https://github.com/ChongZhiJie0216/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/114492-chongzhijie/",
-        "bio": "A novice programmer",
-        "icon": "https://i.imgur.com/SfBmYmw.png",
-        "title": "ChongZhiJie's Repository",
-        "index": 44
-    },
-    {
-        "url": "https://github.com/chrizzo84/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/135280-chrizzo/",
-        "bio": "One of many who would like to contribute to the Unraid community as well.",
-        "icon": "https://raw.githubusercontent.com/chrizzo84/unraid-templates/main/images/self/chrizzo84.jpg",
-        "DonateLink": "https://paypal.me/CGrugel",
-        "DonateText": "If you like my work, feel free to PayPal me a coffee.",
-        "title": "chrizzo's Repository",
-        "index": 45
-    },
-    {
-        "url": "https://github.com/Cirx08/Unraid",
-        "profile": "https://forums.unraid.net/profile/288718-cirx08/",
-        "bio": "Software developer by day, software developer by night...",
-        "icon": "https://raw.githubusercontent.com/Memtly/Memtly.Assets/master/Logos/Community/Memtly.png",
-        "DonateLink": "https://buymeacoffee.com/memtly",
-        "DonateText": "BuyMeACoffee",
-        "WebPage": "https://github.com/Memtly",
-        "title": "Cirx08's Repository",
-        "index": 46
-    },
-    {
-        "url": "https://github.com/giuseppe99barchetta/SuggestArr",
-        "profile": "https://forums.unraid.net/profile/281768-ciuse99/",
-        "bio": "The Official SuggestArr Repository",
-        "icon": "https://raw.githubusercontent.com/giuseppe99barchetta/SuggestArr/master/unraid/logo.png",
-        "DonateLink": "https://buymeacoffee.com/suggestarr",
-        "DonateText": "If you appreciate our work, please consider supporting us by buying us a coffee!",
-        "title": "ciuse99's Repository",
-        "index": 47
-    },
-    {
-        "url": "https://github.com/ck9393/fanctrlplus",
-        "profile": "https://forums.unraid.net/profile/242702-ckchong/",
-        "bio": "FanCtrl Plus author. Personal project for Unraid, developed from real-world needs.",
-        "icon": "https://raw.githubusercontent.com/ck9393/fanctrlplus/main/images/fanctrlplus.png",
-        "DonateLink": "https://www.paypal.com/paypalme/cck9393",
-        "DonateText": "If you like my work, please consider donating!",
-        "Forum": "https://forums.unraid.net/topic/191722-plugin-fancrtl-plus/",
-        "title": "ck9393's Repository",
-        "index": 48
-    },
-    {
-        "url": "https://github.com/cmccambridge/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/83181-cmccambridge/",
-        "bio": "Hello! I maintain a few containers that support my home automation projects. Hopefully they're valuable to you as well! Please let me know through their support threads and GitHub Issues if you encounter any problems. This is a side project for me, so I'm not immediately responsive, but I will try to get back to you and help sort things out if I can.",
-        "icon": "https://raw.githubusercontent.com/cmccambridge/unraid-templates/master/cmccambridge/avatar.jpg",
-        "title": "cmccambridge's Repository",
-        "index": 49
-    },
-    {
-        "url": "https://github.com/cmoro-deusto/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284950-cmoro-gondor/",
-        "bio": "Just a grumpy sysadmin/developer.",
-        "icon": "https://avatars.githubusercontent.com/u/1205035?v=4",
-        "title": "cmoro-gondor's Repository",
-        "index": 50
-    },
-    {
-        "url": "https://github.com/Cobbert/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/129102-cobb/",
-        "bio": "I make templates for things I like as I find them.",
-        "icon": "https://raw.githubusercontent.com/Cobbert/unraid-templates/main/72e78935ce9e246e918fa9e8ebf2d1578044f4cf_full.jpg",
-        "DonateLink": "https://www.paypal.com/donate/?business=RSYPKTC78X566<no_recurring=0<currency_code=USD",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "cobb's Repository",
-        "index": 51
-    },
-    {
-        "url": "https://github.com/Collectathon/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/209526-collectathon/",
-        "bio": "Templates for projects I like that don't exist yet.",
-        "icon": "https://raw.githubusercontent.com/Collectathon/unraid-templates/main/icons/avatar.png",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=E34Z6V3XTDTVL",
-        "DonateText": "A cup of hot chocolate for making your day a bit easier.",
-        "title": "Collectathon's Repository",
-        "index": 52
-    },
-    {
-        "url": "https://github.com/CollinHeist/UnraidConfig",
-        "profile": "https://forums.unraid.net/profile/172758-collinheist/",
-        "bio": "Creator of the TitleCardMaker",
-        "icon": "https://avatars.githubusercontent.com/u/17693271",
-        "DonateLink": "https://www.buymeacoffee.com/CollinHeist",
-        "DonateText": "If you like my work please consider Donating. Thanks!",
-        "Reddit": "https://www.reddit.com/user/CollinHeist",
-        "Discord": "https://discord.gg/bJ3bHtw8wH",
-        "title": "CollinHeist's Repository",
-        "index": 53
-    },
-    {
-        "url": "https://github.com/Core-i99/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/151311-core-i99/",
-        "bio": "Creating and maintaining templates for Unraid Docker containers.",
-        "icon": "https://raw.githubusercontent.com/Core-i99/unraid-docker-templates/main/templates/icons/avatar.png",
-        "title": "Core-i99's Repository",
-        "index": 54
-    },
-    {
-        "url": "https://github.com/coreylane/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/146143-coreylane/",
-        "bio": "Cloud and DevOps guy contributing useful tools to the CA portfolio with a\n        focus on high-quality images, efficiency, and open-source projects.",
-        "icon": "https://raw.githubusercontent.com/coreylane/unraid-ca-templates/master/images/avatar.jpeg",
-        "title": "coreylane's Repository",
-        "index": 55
-    },
-    {
-        "url": "https://github.com/corgan2222/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/102466-corgan/",
-        "bio": "IoT-Project Engineer",
-        "icon": "https://raw.githubusercontent.com/corgan2222/unraid-templates/main/img/avatar.png",
-        "DonateLink": "https://paypal.me/StefanKnaak",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://github.com/corgan2222",
-        "title": "corgan's Repository",
-        "index": 56
-    },
-    {
-        "url": "https://github.com/CorneliousJD/Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/78194-corneliousjd/",
-        "bio": "I am mostly taking other developers containers and building Unraid templates for them. I prefer to do this with official containers sraight from the devs when possible!",
-        "icon": "https://raw.githubusercontent.com/CorneliousJD/Docker-Templates/master/icons/corneliousjd.png",
-        "DonateLink": "http://paypal.me/corneliousjd",
-        "DonateText": "Donate",
-        "WebPage": "http://corneliousjd.com",
-        "title": "CorneliousJD's Repository",
-        "index": 57
-    },
-    {
-        "url": "https://github.com/Joey291/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/99592-cornflake/",
-        "bio": "Just trying to do my part by adding useful Containers",
-        "icon": "https://github.com/Joey291/unraid-templates/raw/main/templates/profile.jpeg",
-        "title": "Cornflake's Repository",
-        "index": 58
-    },
-    {
-        "url": "https://github.com/ctrlaltd1337ed/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/84709-ctrlaltd1337/",
-        "bio": "I create Unraid templates for app developers that either don't use Unraid, or don't want to maintain them. If there are any issues with my templates, check out the forums for my support thread.",
-        "icon": "https://raw.githubusercontent.com/ctrlaltd1337ed/unraid-templates/refs/heads/main/avatar.png",
-        "Forum": "https://forums.unraid.net/topic/188012-support-ctrlaltd1337s-unraid-templates/",
-        "title": "ctrlaltd1337's Repository",
-        "index": 59
-    },
-    {
-        "url": "https://github.com/CtznSniiips/UnraidTemplates",
-        "profile": "https://forums.unraid.net/profile/98131-ctznsnips/",
-        "bio": "Personal project tinkerer",
-        "icon": "https://github.com/CtznSniiips.png",
-        "DonateLink": "https://paypal.me/CtznSniiips",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "CtznSnips' Repository",
-        "index": 60
-    },
-    {
-        "url": "https://github.com/Cyberschorsch/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279951-cyberschorsch/",
-        "bio": "Creating docker templates for the awesome Unraid Community!",
-        "icon": "https://avatars.githubusercontent.com/u/273226?v=4",
-        "title": "Cyberschorsch's Repository",
-        "index": 61
-    },
-    {
-        "url": "https://github.com/AnimaI/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126104-d0ooo/",
-        "bio": "Docker container templates for Bitcoin infrastructure on Unraid systems.",
-        "icon": "https://raw.githubusercontent.com/AnimaI/unraid-templates/master/ca_profile/avatar.jpg",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=8L2DNWLVUFNGJ",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "D0ooo's Repository",
-        "index": 62
-    },
-    {
-        "url": "https://github.com/d3vyce/unraid-template",
-        "profile": "https://forums.unraid.net/profile/99205-d3vyce/",
-        "bio": "Developer",
-        "icon": "https://avatars.githubusercontent.com/u/44915747?v=4",
-        "title": "d3vyce's Repository",
-        "index": 63
-    },
-    {
-        "url": "https://github.com/JakeShirley/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/101291-darknavi/",
-        "bio": "Casual Unraid user.",
-        "icon": "https://avatars.githubusercontent.com/jakeshirley",
-        "DonateLink": "https://paypal.me/darknavi",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "darknavi's Repository",
-        "index": 64
-    },
-    {
-        "url": "https://github.com/jordan-dalby/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/281718-data-jordan/",
-        "bio": "Creating containers for some useful apps I've made!",
-        "icon": "https://avatars.githubusercontent.com/u/49979347?v=4",
-        "DonateLink": "https://ko-fi.com/zalosath",
-        "DonateText": "Donations are not necessary, but are greatly appreciated.",
-        "title": "data-jordan's Repository",
-        "index": 65
-    },
-    {
-        "url": "https://github.com/furritos/docker-templates",
-        "profile": "https://forums.unraid.net/profile/149001-deadfeet/",
-        "bio": "Containerizing various applications onto the Unraid platform",
-        "icon": "https://raw.githubusercontent.com/furritos/docker-templates/master/furritos/images/furritos_512_button.png",
-        "title": "DeadFeet's Repository",
-        "index": 66
-    },
-    {
-        "url": "https://github.com/D3lta/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281050-decrevi/",
-        "bio": "Just another random cat on the internet doing a bunch of secret cat stuff",
-        "icon": "https://github.com/D3lta.png",
-        "DonateLink": "https://github.com/sponsors/D3lta",
-        "DonateText": "Buy a coffee for D3lta",
-        "WebPage": "https://github.com/D3lta",
-        "title": "decrevi's Repository",
-        "index": 67
-    },
-    {
-        "url": "https://github.com/diamkil/docker-templates",
-        "profile": "https://forums.unraid.net/profile/114067-diamkil/",
-        "bio": "I create custom templates for docker hub images that are not on Unraid by bigger sources like binhex or linuxserver",
-        "icon": "https://raw.githubusercontent.com/diamkil/docker-templates/master/diamkil/images/diamkil.png",
-        "title": "diamkil's Repository",
-        "index": 68
-    },
-    {
-        "url": "https://github.com/DiamondPrecisionComputing/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/91956-biggiesize/",
-        "bio": "Just a guy with a computer writing code and helping others.",
-        "icon": "https://github.com/DiamondPrecisionComputing/unraid-templates/blob/main/Profile%20Picture%20reverted.jpg?raw=true",
-        "DonateLink": "https://paypal.me/DiamondPrecision",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Diamond Precision Computing's Repository",
-        "index": 69
-    },
-    {
-        "url": "https://github.com/digiblur/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/75995-digiblur/",
-        "bio": "Just some Random dude making docker container templates to save you a bunch of clicks and research.",
-        "icon": "https://raw.githubusercontent.com/digiblur/unraid-docker-templates/master/images/digiblur.png",
-        "DonateLink": "https://www.paypal.me/digiblurDIY",
-        "DonateText": "If you like my work please consider Donating.",
-        "Facebook": "https://facebook.digiblur.com",
-        "Twitter": "https://twitter.com/digiblur",
-        "Discord": "https://discord.digiblur.com",
-        "WebPage": "https://www.digiblur.com",
-        "title": "digiblur's Repository",
-        "index": 70
-    },
-    {
-        "url": "https://github.com/disbedan015/nadekobotv4-unraid",
-        "profile": "https://forums.unraid.net/profile/115097-disbedan015/",
-        "bio": "Created Docker image as I didn't see an updated one for an app and I may start doing that for other apps I use",
-        "icon": "https://github.com/disbedan015/NadekoBotv4-Docker/blob/master/DAB-500.png?raw=true",
-        "DonateLink": "https://nadekobot.readthedocs.io/en/v4/donate/",
-        "DonateText": "Donation link is for the origial other of the software",
-        "title": "disbedan015's Repository",
-        "index": 71
-    },
-    {
-        "url": "https://github.com/djismgaming/docker-templates",
-        "profile": "https://forums.unraid.net/profile/124577-djismgaming/",
-        "bio": "Helping other developers get their great applications published as an Unraid template. :D",
-        "icon": "https://raw.githubusercontent.com/djismgaming/docker-templates/main/djismGAMING/img/me.jpg",
-        "DonateLink": "https://ko-fi.com/djismgaming",
-        "DonateText": "If I helped you in some way, you could consider donating.",
-        "Twitter": "https://twitter.com/djismgaming",
-        "title": "djismgaming's Repository",
-        "index": 72
-    },
-    {
-        "url": "https://github.com/jlesage/docker-templates",
-        "profile": "https://forums.unraid.net/profile/73771-djoss/",
-        "bio": "Creator of many Docker containers for great applications.  All containers are developed with simplicity and easy of use in mind.  Being based on Alpine Linux, they are lightweight and contain only what is required to run the dockerized application.",
-        "icon": "https://github.com/jlesage.png",
-        "DonateLink": "https://paypal.me/JocelynLeSage/0usd",
-        "DonateText": "If you like my work please consider donating.",
-        "title": "Djoss' Repository",
-        "index": 73
-    },
-    {
-        "url": "https://github.com/dkeners/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287661-dkeners/",
-        "bio": "Maintaining templates for services I enjoy using; hopefully you enjoy them too :)",
-        "icon": "https://github.com/dkeners/unraid-templates/blob/main/dkeners/images/pfp.jpg?raw=true",
-        "DonateLink": "https://dankenerson.com/donate",
-        "DonateText": "I\u2019m just copy-pasting XML files here. Please consider donating to the creators of the projects you love. If you still feel like sharing a little something after that, I wouldn't mind a cup o' tea! \ud83d\ude09",
-        "title": "dkeners' Repository",
-        "index": 74
-    },
-    {
-        "url": "https://github.com/dlandon/docker.templates",
-        "profile": "https://forums.unraid.net/profile/6013-dlandon/",
-        "bio": "Developer of the Unassigned Devices (UD) plugin for mounting disks and remote NFS/SMB shares for local access.  Disk devices can be hot plugged and scripts automatically run for backup purposes.  Encrypted disks are supported.\n\tCreator of the per share Recycle Bin for deleted files from SMB shares.\n\tAlso have several other utility plugins to help with tweaking and managing your Unraid server.",
-        "icon": "https://raw.githubusercontent.com/dlandon/docker.templates/master/avatar.png",
-        "DonateLink": "https://www.paypal.com/us/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=EJGPC7B5CS66E",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "dlandon's Repository",
-        "index": 75
-    },
-    {
-        "url": "https://github.com/yannisalexiou/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283014-yannisalexiou/",
-        "bio": "iOS Tech Lead passionate about developer tooling and automation. \n    I create lightweight, production-ready Docker containers focused on developer workflows \u2014 like real-time App Store Connect webhook proxies for Slack and Microsoft Teams.\n    \n    All my containers follow a clear purpose: minimal, secure, and easy to integrate into CI/CD or self-hosted environments.",
-        "icon": "https://gravatar.com/avatar/c93735d1994346485c1593e5808d3750?size=256",
-        "DonateLink": "https://coff.ee/alexiou",
-        "DonateText": "If my work helps your workflow, consider supporting it \u2615",
-        "title": "Docked by Yannis' Repository",
-        "index": 76
-    },
-    {
-        "url": "https://github.com/Donimax/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/266669-donimax/",
-        "bio": "I am too lazy to find a profile description.",
-        "icon": "https://avatars.githubusercontent.com/u/35191173?v=4",
-        "WebPage": "https://github.com/Donimax",
-        "title": "Donimax's Repository",
-        "index": 77
-    },
-    {
-        "url": "https://github.com/donkevlar/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/86041-donkevlar/",
-        "bio": "I like to fail at Python.",
-        "icon": "https://donkevlar.github.io/Unraid-Docker-Templates/images/avatar.png",
-        "Forum": "https://forums.unraid.net/profile/86041-donkevlar/",
-        "title": "DonKevlar's Repository",
-        "index": 78
-    },
-    {
-        "url": "https://github.com/dopeytree/Unraid-templates",
-        "profile": "https://forums.unraid.net/profile/183052-dopeytree/",
-        "bio": "Mostly my own apps. A tinkering open-source developer & fellow Unraid user. All that matters is that you are making something you love, to the best of your ability, here & now \u2764\ufe0f\u200d\ud83d\udd25",
-        "icon": "https://github.com/dopeytree.png",
-        "DonateLink": "https://github.com/sponsors/dopeytree",
-        "DonateText": "Support my projects",
-        "Forum": "https://forums.unraid.net/topic/194221-support-dopeytree-docker-templates/",
-        "WebPage": "https://ed-stone.co.uk",
-        "title": "dopeytree's Repository",
-        "index": 79
-    },
-    {
-        "url": "https://github.com/dorgan/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/78375-dorgan/",
-        "bio": "Creator/Maintainer of Network Stats plugin as well as Plex Streams plugin",
-        "icon": "https://raw.githubusercontent.com/dorgan/unraid-templates/master/images/avatar.jpg",
-        "DonateLink": "https://paypal.me/dorgan1983",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "dorgan's Repository",
-        "index": 80
-    },
-    {
-        "url": "https://github.com/catalinberta/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/258399-dracon/",
-        "bio": "Creating various (hopefully useful) containers and open source services.",
-        "icon": "https://catalinberta.com/files/me/avatar/300x300.jpg",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=42KHL5J2X3ASQ",
-        "DonateText": "If you like my work please consider Donating.",
-        "Discord": "https://eq6w.short.gy/discord-invite",
-        "title": "dracon's Repository",
-        "index": 81
-    },
-    {
-        "url": "https://github.com/deasmi/unraid-ca",
-        "profile": "https://forums.unraid.net/profile/73313-dsmith44/",
-        "bio": "I'm Dean and I occasionally fiddle with things like this.",
-        "icon": "https://en.gravatar.com/userimage/432758/d39e91adf4f2fa95de28d4a64610dc69.jpeg",
-        "DonateLink": "https://www.justgiving.com/fundraising/unraid-tailscale",
-        "DonateText": "If you like my work please consider donating to cancer research at https://www.justgiving.com/fundraising/unraid-tailscale.",
-        "title": "dsmith44's Repository",
-        "index": 82
-    },
-    {
-        "url": "https://github.com/dkaser/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/244077-edacerton/",
-        "bio": "Building solutions for problems I encounter.",
-        "icon": "https://raw.githubusercontent.com/dkaser/unraid-plugins/main/avatar.jpg",
-        "DonateLink": "https://github.com/sponsors/dkaser",
-        "DonateText": "If you like my work please consider donating.",
-        "title": "EDACerton's Repository",
-        "index": 83
-    },
-    {
-        "url": "https://github.com/eibex/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/268287-eibe/",
-        "bio": "A collection of Unraid templates for software that I created (often alongside amazing contributors) and maintain. I am a hobbyist, not a full-fledged developer.",
-        "icon": "https://avatars.githubusercontent.com/u/40539455?v=4",
-        "WebPage": "https://github.com/eibex",
-        "title": "Eibe's Repository",
-        "index": 84
-    },
-    {
-        "url": "https://github.com/EldonMcGuinness/UnraidCA",
-        "profile": "https://forums.unraid.net/profile/261788-eldonmcguinness/",
-        "bio": "Creating apps and the like to make life easier.",
-        "icon": "https://gravatar.com/userimage/133334237/5eb978c3eb400d3478a2eb9d8fa899be.jpeg?size=256",
-        "DonateLink": "https://www.paypal.me/progressivethinkin",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "EldonMcGuiness' Repository",
-        "index": 85
-    },
-    {
-        "url": "https://github.com/EMP83/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/271480-emp83/",
-        "bio": "EMP83, making some template to help.",
-        "icon": "https://raw.githubusercontent.com/EMP83/unraid-templates/main/images/Crysis.jpg",
-        "DonateLink": "https://ko-fi.com/emp83",
-        "DonateText": "Don't donate to me! Instead, please donate the creators of the apps, but if you insist.",
-        "title": "emp83's Repository",
-        "index": 86
-    },
-    {
-        "url": "https://github.com/ep1cman/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/69221-ep1cman/",
-        "bio": "Blue haired, maker, hacker and engineer.",
-        "icon": "https://avatars.githubusercontent.com/u/5303409",
-        "DonateLink": "https://www.buymeacoffee.com/ep1cman/",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://github.com/ep1cman",
-        "title": "ep1cman's Repository",
-        "index": 87
-    },
-    {
-        "url": "https://github.com/error311/UNRAID_COMMUNITY_APPS",
-        "profile": "https://forums.unraid.net/profile/207982-error311/",
-        "bio": "Creating web apps and tools for automation. Always trying to learn new things and improve.",
-        "icon": "https://github.com/error311/multi-file-upload-editor-docker/blob/2230ec266f24384b3b3ea73de2b78dad1549a7ab/I_am_Error.png?raw=true",
-        "title": "error311's Repository",
-        "index": 88
-    },
-    {
-        "url": "https://github.com/Eurotimmy/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/175441-eurotimmy/",
-        "bio": "Giving something back to the Unraid community... I think.",
-        "icon": "https://raw.githubusercontent.com/Eurotimmy/unraid-templates/main/bubble.png",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=NU5FVN8NDE4S8",
-        "DonateText": "I make the templates; you make the magic. If this was useful, shout me a coffee?\u2615",
-        "title": "Eurotimmy's Repository",
-        "index": 89
-    },
-    {
-        "url": "https://github.com/ItJustFox/unraidtemplate",
-        "profile": "https://forums.unraid.net/profile/142238-fantucie/",
-        "bio": "Hello, I am Fantucie, also know has ItJustFox ! I am a french developper using Java JScript and Json, making mods/3DModels for Minecraft principally. Mostly fan of Sinon from GGO, I can be a bit shy, but i promise that one day, we will talk together !",
-        "icon": "https://avatars.githubusercontent.com/u/42358087?v=4",
-        "title": "Fantucie's Repository",
-        "index": 90
-    },
-    {
-        "url": "https://github.com/avpnusr/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/126700-fatzcat/",
-        "bio": "Docker container creator, full-time engineer and openminded geek. That's all ...",
-        "icon": "https://github.com/avpnusr/unraid-ca-templates/raw/master/img/profile.png",
-        "title": "FatzCat's Repository",
-        "index": 91
-    },
-    {
-        "url": "https://github.com/feederbox826/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281190-feederbox826/",
-        "bio": "Community developer focused on extending stashapp/stash",
-        "icon": "https://feederbox.cc/profile.jpg",
-        "DonateLink": "https://opencollective.com/stashapp",
-        "DonateText": "Sustain the continued development of stash",
-        "WebPage": "https://feederbox.cc",
-        "title": "feederbox826's Repository",
-        "index": 92
-    },
-    {
-        "url": "https://github.com/AriaGomes/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/107309-figro/",
-        "bio": "Junior Developer that likes to mess around with dockers in his spare time",
-        "icon": "https://raw.githubusercontent.com/AriaGomes/Unraid-Templates/master/Images/profile.png",
-        "DonateLink": "https://www.buymeacoffee.com/ariagomes",
-        "DonateText": "Buy me a coffee :)",
-        "title": "Figro's Repository",
-        "index": 93
-    },
-    {
-        "url": "https://github.com/fileflows/FileFlowsUnraid",
-        "profile": "https://forums.unraid.net/profile/1117-reven/",
-        "bio": "Developer of FileFlows",
-        "icon": "https://avatars.githubusercontent.com/u/958400",
-        "DonateLink": "https://www.patreon.com/revenz",
-        "DonateText": "If you like my work please consider Donating.",
-        "Discord": "https://discord.gg/xbYK8wFMeU",
-        "WebPage": "https://fileflows.com/",
-        "title": "fileflows's Repository",
-        "index": 94
-    },
-    {
-        "url": "https://github.com/findthelorax/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169140-findthelorax/",
-        "bio": "Full Stack Developer with a passion for technology and a love for Open Source. I am always looking for ways to improve my skills and learn new things. I am a huge fan of Unraid and the community that surrounds it.",
-        "icon": "https://avatars.githubusercontent.com/u/83841899?v=4",
-        "DonateLink": "https://buymeacoffee.com/findthelorax",
-        "DonateText": "If you like my work please consider donating.",
-        "title": "Findthelorax's Repository",
-        "index": 95
-    },
-    {
-        "url": "https://github.com/fithwum/files-for-dockers",
-        "profile": "https://forums.unraid.net/profile/82177-fithwum/",
-        "bio": "I have made a few dockers now.  \n    Might make others when or if they might be needed.",
-        "icon": "https://gitea.fithwum.tech/fithwum/files-for-dockers/raw/branch/master/icons/fithwum.png",
-        "DonateLink": "https://checkout.square.site/pay/340d93c602a042b8a223a2f7c184a6a2",
-        "DonateText": "Buy me a coffee if you like.",
-        "WebPage": "https://hoots.fithwum.tech",
-        "title": "fithwum's Repository",
-        "index": 96
-    },
-    {
-        "url": "https://github.com/Cleanuparr/unraid",
-        "profile": "https://forums.unraid.net/profile/282380-flamin/",
-        "bio": "Creating software to make my life easier and to learn.",
-        "icon": "https://raw.githubusercontent.com/flmorg/unraid/main/templates/img/tom.jpg",
-        "DonateLink": "https://buymeacoffee.com/flaminel",
-        "DonateText": "If I made your life just a tiny bit easier, consider buying me a coffee!",
-        "title": "Flamin's Repository",
-        "index": 97
-    },
-    {
-        "url": "https://github.com/olehj/unraid",
-        "profile": "hhttps://forums.unraid.net/profile/86216-flamongole/",
-        "bio": "Creator of Disk Location plugin for Unraid.",
-        "icon": "https://raw.githubusercontent.com/olehj/unraid/master/flamongo.png",
-        "DonateLink": "https://www.paypal.me/olehj",
-        "DonateText": "Feel free to donate me a beer if you like my plugin!",
-        "Forum": "https://forums.unraid.net/profile/86216-olehj/",
-        "title": "FlamongOle's Repository",
-        "index": 98
-    },
-    {
-        "url": "https://github.com/nzzane/nzzane-unraid-repo",
-        "profile": "https://forums.unraid.net/profile/113405-flippinturt/",
-        "bio": "Just here to help the community out and make fun things ;)",
-        "icon": "https://raw.githubusercontent.com/nzzane/nzzane-unraid-repo/main/Icons/zrh_profile.jpg",
-        "DonateLink": "https://www.paypal.com/donate?hosted_button_id=4CL2REKSGRLWA",
-        "DonateText": "If you appreciate my work, then please consider buying me a Snacc :D",
-        "WebPage": "https://turtledev.nz",
-        "title": "FlippinTurt's Repository",
-        "index": 99
-    },
-    {
-        "url": "https://github.com/manyfold3d/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/277882-floppyuk/",
-        "bio": "Building a self-hosted 3d model organisation app for 3d printing enthusiasts",
-        "icon": "https://manyfold.app/images/logo.png",
-        "DonateLink": "https://opencollective.com/manyfold",
-        "DonateText": "Help us make Manyfold even better!",
-        "WebPage": "https://manyfold.app",
-        "title": "FloppyUK's Repository",
-        "index": 100
-    },
-    {
-        "url": "https://github.com/Lowess/docker-templates-unraid",
-        "profile": "https://forums.unraid.net/profile/161755-florian-dambrine/",
-        "bio": "Passionate DevOps engineer crafting Docker containers with a unique twist. My approach goes\n        beyond conventional methods, focusing on lean containers with only essential dependencies.\n        Each container dynamically fetches and updates the application upon start/restart, ensuring\n        seamless operation. Join me in redefining the Unraid experience, one container at a time.",
-        "icon": "https://raw.githubusercontent.com/Lowess/docker-templates-unraid/main/Lowess/images/avatar.png",
-        "title": "Florian Dambrine's Repository",
-        "index": 101
-    },
-    {
-        "url": "https://github.com/framedr0p/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290788-framedr0p/",
-        "bio": "I'm new so be kind :-D",
-        "icon": "https://github.com/framedr0p/unraid-templates/blob/master/avatar.jpeg",
-        "DonateLink": "https://paypal.me/mex990",
-        "DonateText": "If you appreciate my work, then please consider buying me a drink :D",
-        "title": "framdr0p's Repository",
-        "index": 102
-    },
-    {
-        "url": "https://github.com/Frooodle/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/128782-froodle/",
-        "bio": "Hopefully working on more CICD related things in future, maybe also plex related things. Feel free to PM me for help.",
-        "icon": "https://raw.githubusercontent.com/Frooodle/unraid-templates/main/logos/Froodle.png",
-        "DonateLink": "https://www.paypal.com/paypalme/FroodlePlex",
-        "DonateText": "You shouldn't donate, I have not made these docker images only did some config.. \n  But if you really want to, thanks :)",
-        "title": "Froodle's Repository",
-        "index": 103
-    },
-    {
-        "url": "https://github.com/connorgallopo/tracearr-unraid-template",
-        "profile": "https://forums.unraid.net/profile/281348-gallapagos/",
-        "bio": "Tech Leader, Software Engineer, and Open Source maintainer. Creator of Tracearr.",
-        "icon": "https://avatars.githubusercontent.com/u/21372032",
-        "DonateLink": "https://github.com/sponsors/connorgallopo",
-        "DonateText": "If you like my work, please consider sponsoring me on GitHub",
-        "Discord": "https://discord.gg/a7n3sFd2Yw",
-        "WebPage": "https://tracearr.com",
-        "title": "Gallapagos' Repository",
-        "index": 104
-    },
-    {
-        "url": "https://github.com/GeiserX/docker-templates",
-        "profile": "https://forums.unraid.net/profile/276896-geiserx/",
-        "bio": "Self-hosted Docker images for networking, media management, backups, and productivity. Multi-arch (amd64/arm64) wherever possible.",
-        "icon": "https://github.com/GeiserX.png",
-        "WebPage": "https://geiser.cloud",
-        "title": "geiserx's Repository",
-        "index": 105
-    },
-    {
-        "url": "https://github.com/giganode/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/105464-giganode/",
-        "bio": "I'm just beginning.",
-        "icon": "https://raw.githubusercontent.com/giganode/unraid-plugins/main/avatar.jpg",
-        "DonateLink": "https://paypal.me/MReimer5592",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "giganode's Repository",
-        "index": 106
-    },
-    {
-        "url": "https://github.com/GlassedSilver/unRAID-CAs",
-        "profile": "https://forums.unraid.net/profile/91241-glassed-silver",
-        "bio": "Unraid Community Applications I created because I didn't find them.\n    I create these for personal use and share them for anyone else to enjoy.\n    \n    I provide support for them over at the Unraid Forums, where each CA gets its own thread, because reading or asking in a thread that's a lump of 10 containers is convoluted.\n    \n    Please keep in mind that whilst I will support setting these up for your scenario to the best of my abilities, I cannot provide the same level of support for the applications themselves, especially if you encountered a bug. If you do, I strongly recommend you go to the official bug tracker/other support outlet.",
-        "icon": "https://avatars.githubusercontent.com/u/1912133",
-        "Forum": "https://forums.unraid.net/profile/91241-glassed-silver/",
-        "Twitter": "https://twitter.com/GlassedSilver",
-        "title": "Glassed Silver's Repository",
-        "index": 107
-    },
-    {
-        "url": "https://github.com/glls/Docker-Templates-Unraid",
-        "profile": "https://forums.unraid.net/profile/272335-glls/",
-        "bio": "Software Engineer | Docker templates for Unraid. Retro enthusiast / Open Source supporter. Learn more on my page.",
-        "icon": "https://avatars.githubusercontent.com/u/392030?v=4",
-        "DonateLink": "https://www.paypal.me/GeorgeLitos",
-        "DonateText": "If you like my work please consider donating.",
-        "Forum": "https://forums.unraid.net/profile/272335-glls/",
-        "WebPage": "https://georgelitos.com/",
-        "title": "glls' Repository",
-        "index": 108
-    },
-    {
-        "url": "https://github.com/Goobaroo/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/113292-goobaroo/",
-        "bio": "I like to publish things I create for myself.  Right now creating modded minecrafte server containers. Let me know if you have any requests.",
-        "icon": "https://raw.githubusercontent.com/Goobaroo/unraid-templates/main/goobaroo.png",
-        "DonateLink": "https://ko-fi.com/goobaroo",
-        "DonateText": "If you like my work, you can buy me a coffee. But not at all expected.",
-        "title": "Goobaroo's Repository",
-        "index": 109
-    },
-    {
-        "url": "https://github.com/RichKidsDev/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/156616-grafgenixs/",
-        "bio": "I enjoy creating templates for Community Applications in Unraid to make it easier for users to install Docker containers. This is a passion project for me, and I love contributing to the Unraid community by simplifying the process and sharing my work.",
-        "icon": "https://github.com/RichKidsDev/Unraid-Templates/blob/main/logo-grafgenixs.png?raw=true",
-        "title": "GrafGenixs' Repository",
-        "index": 110
-    },
-    {
-        "url": "https://github.com/Greite/unraid-templates",
-        "profile": null,
-        "bio": "GreiteTurtle's Unraid templates. Source-available under the MIT license. Bug reports and pull requests welcome on GitHub.",
-        "icon": "https://github.com/Greite.png",
-        "WebPage": "https://github.com/Greite/unraid-templates",
-        "title": "GreiteTurtle",
-        "index": 111
-    },
-    {
-        "url": "https://github.com/nwithan8/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/81372-grtgbln/",
-        "bio": "An open-source developer and fellow Unraid user, creating and maintaining templates for the community. Some templates are for my own projects, but I'm happy to add any template that is requested.",
-        "icon": "https://codeberg.org/nwithan8/assets/raw/branch/main/images/avatar/goblin/goblin_300.png",
-        "DonateLink": "https://www.buymeacoffee.com/nwithan8",
-        "DonateText": "If you like an app, please donate to the respective developers; I'm just writing XML files over here. But if you have some change to spare afterwards, maybe chuck me a buck?",
-        "Forum": "https://forums.unraid.net/topic/133764-support-grtgbln-docker-templates",
-        "WebPage": "https://github.com/nwithan8/unraid_templates",
-        "title": "grtgbln's Repository",
-        "index": 112
-    },
-    {
-        "url": "https://github.com/gthrift/gthrift-unraid-ca",
-        "profile": "https://forums.unraid.net/profile/293215-gthrift/",
-        "bio": "Building apps that I want to use for myself and sharing with the community.",
-        "title": "gthrift's Repository",
-        "index": 113
-    },
-    {
-        "url": "https://github.com/soerentsch/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/146285-gucky79/",
-        "bio": "Don't PANIC! And carry a towel. Searching Milk and Kahlua for the Dude. Earl grey, hot! And the rest of my time i'm a Developer and Maker with passion ;-)",
-        "icon": "https://avatars.githubusercontent.com/u/5426009?v=4",
-        "DonateLink": "https://paypal.me/SoerenSchwirsch",
-        "DonateText": "Help support my work by buying me a beer",
-        "title": "gucky79's Repository",
-        "index": 114
-    },
-    {
-        "url": "https://github.com/GuildDarts/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/80260-guilddarts/",
-        "bio": "Having fun playing with my Unraid server ^_^",
-        "icon": "https://raw.githubusercontent.com/GuildDarts/unraid-ca-templates/master/avatar.png",
-        "title": "GuildDart's Repository",
-        "index": 115
-    },
-    {
-        "url": "https://github.com/guniv/unraid-ca-apps",
-        "profile": "https://forums.unraid.net/profile/178712-guniv/",
-        "bio": "Guy who barely knows what he is doing",
-        "icon": "https://raw.githubusercontent.com/guniv/unraid-ca-apps/master/pic/pic.jpg",
-        "Reddit": "https://www.reddit.com/user/guniv/",
-        "title": "guniv's Repository",
-        "index": 116
-    },
-    {
-        "url": "https://github.com/kylejschultz/unraid-templates",
-        "profile": null,
-        "bio": "Homelab tinkerer. Building open-source tools for self-hosters.",
-        "icon": "https://raw.githubusercontent.com/kylejschultz/unraid-templates/main/nestview/nestview-icon.png",
-        "Discord": "https://discord.gg/TfQ8QX3Ptr",
-        "title": "Gurthyy's Repository",
-        "index": 117
-    },
-    {
-        "url": "https://github.com/guydavis/machinaris-unraid",
-        "profile": "https://forums.unraid.net/profile/126090-guydavis/",
-        "bio": "Unraid enthusiast and Chia (+forks) farmer.",
-        "icon": "https://raw.githubusercontent.com/guydavis/machinaris-unraid/master/guy_davis.png",
-        "Discord": "https://discord.gg/mX4AtMTt87",
-        "WebPage": "https://github.com/guydavis",
-        "title": "guy.davis' Repository",
-        "index": 118
-    },
-    {
-        "url": "https://github.com/bpivk/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/67984-gxs/",
-        "bio": "I create Unraid docker templates for containers I find interesting and/or useful.",
-        "icon": "https://raw.githubusercontent.com/bpivk/unraid-templates/main/images/ca_profile.jpg",
-        "DonateLink": "https://www.paypal.com/paypalme/bpivk",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "gxs' Repository",
-        "index": 119
-    },
-    {
-        "url": "https://github.com/UnknownHiker/unraid-template-kitchenowl",
-        "profile": "https://forums.unraid.net/profile/155012-hansolo97/",
-        "bio": "Doing my best to help filling the gap of services, that dont have a Unraid Template yet. :-)",
-        "icon": "https://codeberg.org/avatars/2cdf72f6241e5b528099558d665454310cf0373b9efe47f03f614ef6b04b23b2?size=512",
-        "WebPage": "https://codeberg.org/HanSolo97",
-        "title": "HanSolo97's Repository",
-        "index": 120
-    },
-    {
-        "url": "https://github.com/prolife86/unraid-templates",
-        "profile": null,
-        "bio": "A self-hosting enthusiast and whisky lover who builds the tools he actually wants to use. From a full-featured web vault for your spirits collection to a native Android companion, that keeps your data where it belongs \u2014 at home.",
-        "icon": "https://raw.githubusercontent.com/prolife86/WhiskyWise/refs/heads/main/Icons/Icon%201.png",
-        "DonateLink": "https://www.paypal.me/SonsyICT",
-        "DonateText": "Help support my work by buying me a coffee",
-        "title": "Heisenbugger's Repository",
-        "index": 121
-    },
-    {
-        "url": "https://github.com/hhftechnology/unraid_app_templates",
-        "profile": "https://forums.unraid.net/profile/282959-hhftechnology/",
-        "bio": "Just another Infrastructure Engineer and Homelab Enthusiast.",
-        "icon": "https://raw.githubusercontent.com/hhftechnology/unraid_app_templates/refs/heads/main/images/hhflogo.png",
-        "title": "hhftechnology's Repository",
-        "index": 122
-    },
-    {
-        "url": "https://github.com/hotio/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/94356-hotio",
-        "bio": "I maintain a few docker images (Ubuntu or Alpine based) and try to deliver incredibly fast updates, all automated and tested before pushing them into the world.",
-        "icon": "https://hotio.dev/webhook-avatars/hotio.png",
-        "DonateLink": "https://hotio.dev/donate",
-        "DonateText": "You can become a GitHub sponsor, use Open Collective or send some Crypto...Affiliate links for VPN providers are on the website.",
-        "Discord": "https://hotio.dev/discord",
-        "WebPage": "https://hotio.dev",
-        "title": "hotio's Repository",
-        "index": 123
-    },
-    {
-        "url": "https://github.com/hsiang-han/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/213571-hsiang/",
-        "bio": "Just some Unraid apps I use and maintain.",
-        "icon": "https://raw.githubusercontent.com/hsiang-han/unraid_templates/main/assets/avatar.png",
-        "DonateLink": "https://github.com/sponsors/hsiang-han",
-        "DonateText": "Like these apps? Support me on GitHub Sponsors.",
-        "title": "hsiang's Repository",
-        "index": 124
-    },
-    {
-        "url": "https://github.com/hudikhq/hoodik-unraid",
-        "profile": "https://forums.unraid.net/profile/228687-htunlogic/",
-        "bio": "Creating applications and containers for myself and sharing them with you with \u2764\ufe0f",
-        "icon": "https://raw.githubusercontent.com/hudikhq/hoodik-unraid/main/images/avatar.jpeg",
-        "DonateLink": "https://paypal.me/htunlogic",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "htunlogic's Repository",
-        "index": 125
-    },
-    {
-        "url": "https://github.com/ibracorp/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/106623-sycotix/",
-        "bio": "We are IBRACORP. We create Docker templates, Guides and YouTube videos to get your homelab set up across a range of needs, from basic all the way to enterprise level. Join our Discord!",
-        "icon": "https://raw.githubusercontent.com/ibracorp/unraid-templates/master/V3Icon.png",
-        "DonateLink": "https://paypal.me/ibracorp",
-        "DonateText": "If you like our work please consider Donating.",
-        "Discord": "https://discord.gg/VWAG7rZ",
-        "WebPage": "https://ibracorp.io",
-        "title": "IBRACORP's Repository",
-        "index": 126
-    },
-    {
-        "url": "https://github.com/ich777/docker-templates",
-        "profile": "https://forums.unraid.net/profile/72388-ich777/",
-        "bio": "Creating Containers and Plugins with the intention to make them as easy as possible to install and use.",
-        "icon": "https://raw.githubusercontent.com/ich777/docker-templates/master/ich777/images/avatar.jpg",
-        "DonateLink": "https://www.paypal.me/chips777",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "ich777's Repository",
-        "index": 127
-    },
-    {
-        "url": "https://github.com/IkerSaint/ZFS-Master-Unraid",
-        "profile": "https://forums.unraid.net/profile/102954-iker/",
-        "bio": "Information Security, Tech Enthusiast, Data Enthusiast, Amateur Developer",
-        "icon": "https://avatars.githubusercontent.com/u/18542097",
-        "DonateLink": "https://www.paypal.com/paypalme/ikersaint",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://ikersaint.medium.com",
-        "title": "Iker's Repository",
-        "index": 128
-    },
-    {
-        "url": "https://github.com/RealFascinated/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/87787-imfascinated/",
-        "bio": "Creating simple and useful Docker containers for users of Unraid and much more!",
-        "icon": "https://git.fascinated.cc/Fascinated/unraid-templates/raw/branch/master/images/profile_picture.webp",
-        "Discord": "https://discord.gg/yjj2U3ctEG",
-        "title": "ImFascinated's Repository",
-        "index": 129
-    },
-    {
-        "url": "https://github.com/ImSkully/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/186901-imskully/",
-        "bio": "Maintaining container templates for community applications, one image at a time.",
-        "icon": "https://github.com/ImSkully.png",
-        "DonateLink": "https://buymeacoffee.com/skully",
-        "DonateText": "If you use any of the applications that I maintain, feel free to support my work by buying me a coffee!",
-        "Discord": "https://skully.tech/discord",
-        "WebPage": "https://skully.tech",
-        "title": "ImSkully's Repository",
-        "index": 130
-    },
-    {
-        "url": "https://github.com/imthenachoman/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/134093-imthenachoman/",
-        "bio": "Nobody special. Just doing this for fun.",
-        "icon": "https://avatars.githubusercontent.com/u/83817?s=400&u=0ce202f0f0cd5d1a653cf86ebec583211f614a73&v=4",
-        "DonateLink": "https://paypal.me/imthenachoman?country.x=US&locale.x=en_US",
-        "DonateText": "If you like my work please consider Donating.",
-        "Reddit": "https://www.reddit.com/user/imthenachoman/",
-        "Twitter": "http://twitter.com/imthenachoman",
-        "WebPage": "https://www.nigam.dev/",
-        "title": "IMTheNachoMan's Repository",
-        "index": 131
-    },
-    {
-        "url": "https://github.com/J000K3R/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/127281-j000k3r/",
-        "bio": "simple Unraid templates",
-        "icon": "https://raw.githubusercontent.com/J000K3R/unraid-templates/refs/heads/main/Images/Joker.jpg",
-        "title": "J000K3R's Repository",
-        "index": 132
-    },
-    {
-        "url": "https://github.com/j1philli/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/84279-j1philli/",
-        "bio": "Amateur developer bringing the tools I use to Unraid.",
-        "icon": "https://avatars.githubusercontent.com/u/3744255?v=4",
-        "Twitter": "https://twitter.com/j1philli",
-        "title": "j1philli's Repository",
-        "index": 133
-    },
-    {
-        "url": "https://github.com/JasonPuglisi/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294612-jasonpuglisi/",
-        "bio": "Hacker, musician, artist, explorer",
-        "icon": "https://avatars.githubusercontent.com/u/5090549",
-        "WebPage": "https://pugli.si",
-        "title": "JasonPuglisi's Repository",
-        "index": 134
-    },
-    {
-        "url": "https://github.com/jbrodriguez/unraid",
-        "profile": "https://forums.unraid.net/profile/593-jbrodriguez/",
-        "bio": "Creator and maintainer of unbalanced and ControlR, specifically developed for Unraid.",
-        "icon": "https://raw.githubusercontent.com/jbrodriguez/unraid/main/jb.png",
-        "DonateLink": "https://jbrio.net/unbalanced",
-        "DonateText": "If you like my work please consider sponsoring.",
-        "title": "jbrodriguez's Repository",
-        "index": 135
-    },
-    {
-        "url": "https://github.com/jcofer555/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/135547-jcofer555/",
-        "bio": "Hi, I'm jcofer555 - I'm a software tech support kind of guy from the United States.\n    I like to provide help and tools to myself and others. For awhile now I have been a\n    discord moderator for the UnraidOfficial discord helping manage things there.\n    Love to collaborate and help others!",
-        "icon": "https://raw.githubusercontent.com/jcofer555/unraid-plugins/main/avatar.jpg",
-        "WebPage": "https://jcofer555.github.io/unraid-projects/",
-        "title": "jcofer555's Repository",
-        "index": 136
-    },
-    {
-        "url": "https://github.com/JeremiahChurch/arc-relay-unraid",
-        "profile": null,
-        "bio": "https://github.com/JeremiahChurch",
-        "icon": "https://raw.githubusercontent.com/JeremiahChurch/arc-relay-unraid/main/images/arc-relay-icon.png",
-        "title": "Jeremiah's Repository",
-        "index": 137
-    },
-    {
-        "url": "https://github.com/AMJidovu/unraid-repository",
-        "profile": "https://forums.unraid.net/profile/86478-jidovu-marius-adrian/",
-        "bio": "I love Unraid and creating Docker containers is one of my hobbies.",
-        "icon": "https://raw.githubusercontent.com/AMJidovu/unraid-repository/master/img/avatar.jpg",
-        "DonateLink": "https://www.paypal.me/xternet",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Jidovu Marius Adrian's Repository",
-        "index": 138
-    },
-    {
-        "url": "https://github.com/dannymate/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/87501-jimrummy101/",
-        "bio": "FOSS and Self-Hosting fan hoping to bring interesting applications to Unraid.",
-        "icon": "https://raw.githubusercontent.com/dannymate/unraid-templates/master/icons/avatar.png",
-        "Twitter": "https://twitter.com/slumbering_cat",
-        "WebPage": "https://github.com/dannymate",
-        "title": "jimrummy101's Repository",
-        "index": 139
-    },
-    {
-        "url": "https://github.com/juusujanar/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/79768-jj9987/",
-        "bio": "Bringing the containers to the users.",
-        "icon": "https://github.com/juusujanar.png",
-        "DonateLink": "https://www.paypal.me/jj9987",
-        "DonateText": "If you like my work and want to buy me a beer, feel free.",
-        "title": "jj9987's Repository",
-        "index": 140
-    },
-    {
-        "url": "https://github.com/jjdenhertog/spotify-to-plex-unraid",
-        "profile": "https://forums.unraid.net/profile/283509-jjdenhertog/",
-        "bio": "Loving music and home automation. Working mostly with TypeScript but a history with many other languages.",
-        "icon": "https://avatars.githubusercontent.com/u/880721?v=4",
-        "DonateLink": "https://buymeacoffee.com/jjdenhertog",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "jjdenhertog's Repository",
-        "index": 141
-    },
-    {
-        "url": "https://github.com/JmzTaylor/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/120824-jmztaylor/",
-        "bio": "Just kinda doing my own thing creating things for my use cases and sharing my work",
-        "icon": "https://raw.githubusercontent.com/jmztaylor/homelab_proxy_unraid/master/avatar.png",
-        "DonateLink": "https://paypal.me/jmztaylor",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "jmztaylor's Repository",
-        "index": 142
-    },
-    {
-        "url": "https://github.com/jgennari/UnraidApps",
-        "profile": "https://forums.unraid.net/profile/212091-joey-gennari/",
-        "bio": "Creating docker containers that I find help for web development.",
-        "icon": "https://1.gravatar.com/avatar/d37630c44ac1bf24b36dab00681eebfc0c0dd549b743f10b6552a405016138f0?size=512",
-        "title": "Joey Gennari's Repository",
-        "index": 143
-    },
-    {
-        "url": "https://github.com/jnbarlow/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/238964-john-barlow/",
-        "bio": "Adding a little spice to Unraid, one app at a time.",
-        "icon": "https://raw.githubusercontent.com/jnbarlow/unraid_templates/main/images/tick.jpg",
-        "DonateLink": "https://paypal.me/jnbarlow",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "John Barlow's Repository",
-        "index": 144
-    },
-    {
-        "url": "https://github.com/tenasi/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/121030-johnnyp/",
-        "bio": "Creating some docker containers that I use myself and want to share with others.",
-        "icon": "https://raw.githubusercontent.com/tenasi/unraid-templates/master/avatar.png",
-        "DonateLink": "https://www.paypal.me/tenasi",
-        "DonateText": "Buy me a beer.",
-        "title": "JohnnyP's Repository",
-        "index": 145
-    },
-    {
-        "url": "https://github.com/jordibrouwer/nextdash",
-        "profile": null,
-        "bio": "Made by Jordi Brouwer, nerd from The Netherlands.",
-        "icon": "https://avatars.githubusercontent.com/u/117413846?v=4",
-        "WebPage": "https://www.jordibrw.nl",
-        "title": "Jordibrw",
-        "index": 146
-    },
-    {
-        "url": "https://github.com/Josh5/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/76627-josh5/",
-        "bio": "Software Developer, DevOps Engineer and Electrical Technician. In my spare time I enjoy writing software for the open-source community. I deal a lot with Docker on a day-to-day basis and have experience in embedded Linux development.",
-        "icon": "https://raw.githubusercontent.com/Josh5/unraid-docker-templates/master/images/josh5.png",
-        "DonateLink": "https://ko-fi.com/josh5coffee",
-        "DonateText": "If you like my work, please consider supporting me on Patreon",
-        "Twitter": "https://twitter.com/jsunnex",
-        "Discord": "https://streamingtech.co.nz/discord",
-        "WebPage": "https://github.com/sponsors/Josh5/",
-        "title": "Josh.5's Repository",
-        "index": 147
-    },
-    {
-        "url": "https://github.com/JSONbored/awesome-unraid",
-        "profile": "https://forums.unraid.net/profile/261555-jsonbored/",
-        "bio": "JSONbored publishes Unraid-first All-in-One containers for self-hosted software that normally requires multi-container setup, manual dependency wiring, or compose-heavy deployment. The focus is practical homelab usability: simpler installation, sane defaults, honest documentation about tradeoffs, and support for advanced users who want to override pieces of the stack.",
-        "icon": "https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/profile.png",
-        "DonateLink": "https://ko-fi.com/jsonbored",
-        "DonateText": "If these AIO templates save you time, please consider supporting ongoing maintenance via Ko-fi (ko-fi.com/jsonbored) or Buy Me a Coffee (buymeacoffee.com/jsonbored).",
-        "Forum": "https://forums.unraid.net/profile/261555-jsonbored/",
-        "Twitter": "https://x.com/jsonbored",
-        "WebPage": "https://aethereal.dev",
-        "title": "JSONbored's Repository",
-        "index": 148
-    },
-    {
-        "url": "https://github.com/DatPat/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169502-jsrk/",
-        "bio": "I am just trying to learn. Not everything I am doing will be perfect right away but I am hoping to improve it over time.",
-        "icon": "https://i.imgur.com/y1D2enH.png",
-        "DonateLink": "https://paypal.me/",
-        "DonateText": "No donation needed.",
-        "WebPage": "https://github.com/DatPat/",
-        "title": "jsrk's Repository",
-        "index": 149
-    },
-    {
-        "url": "https://github.com/JTok/unraid-plugins",
-        "profile": " https://forums.unraid.net/profile/75269-jtok/",
-        "bio": "Developer of the **Unraid.Vmbackup** plugin which uses the **Unraid-Vmbackup** script behind the scenes.",
-        "icon": "https://github.com/JTok.png",
-        "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NG5HGW4Q3CZU4",
-        "DonateText": "Feel free to buy me a beer or coffee :-)",
-        "title": "JTok's Repository",
-        "index": 150
-    },
-    {
-        "url": "https://github.com/juchong/shapeshifter-docker-unraid",
-        "profile": "https://forums.unraid.net/profile/113997-juchong/",
-        "bio": "Sharing useful stuff for others to use on their projects.",
-        "icon": "https://en.gravatar.com/userimage/60078001/c46d1f59af45f33cff47f5354404e4e6.jpg",
-        "DonateLink": "https://www.paypal.com/paypalme/juchong",
-        "DonateText": "If one of my containers helped you out, please consider donating!",
-        "title": "juchong's Repository",
-        "index": 151
-    },
-    {
-        "url": "https://github.com/OpenSageTV/unRAID",
-        "profile": "https://forums.unraid.net/profile/125876-jusjoken/",
-        "bio": "Creating containers and other needed development mostly in the SageTV community",
-        "icon": "https://raw.githubusercontent.com/jusjoken/resources/main/HeadshotCartoon.jpg",
-        "DonateLink": "https://www.patreon.com/user?u=58035567",
-        "DonateText": "Support me on Patreon",
-        "title": "jusjoken's Repository",
-        "index": 152
-    },
-    {
-        "url": "https://github.com/jwillmer/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119261-jwillmer/",
-        "bio": "That's me, nothing more to add.",
-        "icon": "https://raw.githubusercontent.com/jwillmer/unraid-templates/main/images/jwillmer.jpg",
-        "Forum": "https://forums.unraid.net/topic/130458-support-nut-influxdbv2-exporter/",
-        "Twitter": "https://twitter.com/jenswillmer",
-        "WebPage": "https://jwillmer.de",
-        "title": "jwillmer's Repository",
-        "index": 153
-    },
-    {
-        "url": "https://github.com/kaedinger/unraid-ca-xml-templates",
-        "profile": null,
-        "bio": "Software architect of 35 years, now audio engineer, but still creating/maintaining own software products as well as open source.",
-        "icon": "https://raw.githubusercontent.com/kaedinger/unraid-ca-xml-templates/main/ca_profile.png",
-        "DonateLink": "https://www.paypal.me/kaedinger",
-        "DonateText": "If you appreciate my work please consider donating.",
-        "WebPage": "https://kaedinger.de",
-        "Photo": "https://raw.githubusercontent.com/kaedinger/unraid-ca-xml-templates/main/fieldolamps.png",
-        "Video": "https://www.youtube.com/watch?v=Q9WB53jlILQ",
-        "title": "kaedinger's Repository",
-        "index": 154
-    },
-    {
-        "url": "https://github.com/kieraneglin/unraid_ca",
-        "profile": "https://forums.unraid.net/profile/185979-kieran-e/",
-        "bio": "Developer and Linux ISO enthusiast.",
-        "icon": "https://raw.githubusercontent.com/kieraneglin/unraid_ca/master/images/avatar.png",
-        "title": "Kieran E's Repository",
-        "index": 155
-    },
-    {
-        "url": "https://github.com/hofq/docker-templates",
-        "profile": "https://forums.unraid.net/profile/112121-kippenhof/",
-        "bio": "Providing Small/unknown Docker images to the CA application to make them more accessible. If you have a problem with one of my templates, you can write me on Discord: Johannes Walther#",
-        "icon": "https://s.gravatar.com/avatar/f8186422310ef2c5f080314631055a23?s=350",
-        "DonateLink": "https://github.com/hofq/docker-templates/blob/main/Donations.md",
-        "DonateText": "Don't donate to me! Instead, please donate the creators of these amazing apps.",
-        "title": "Kippenhof's Repository",
-        "index": 156
-    },
-    {
-        "url": "https://github.com/Kizaing/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/129591-kizaing/",
-        "bio": "Helping developers dockerize their applications and make them easy to install for everyone everywhere",
-        "icon": "https://raw.githubusercontent.com/Kizaing/Unraid-Templates/main/avatar.jpg",
-        "Twitter": "https://twitter.com/Kizaing",
-        "title": "Kizaing's Repository",
-        "index": 157
-    },
-    {
-        "url": "https://github.com/davidjkling/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/293102-kling/",
-        "bio": "I just want nice things for Unraid.",
-        "icon": "https://raw.githubusercontent.com/davidjkling/unraid-templates/refs/heads/main/static/user_icon.png",
-        "Forum": "https://forums.unraid.net/topic/196521-support-kling-templates",
-        "title": "Kling's Repository",
-        "index": 158
-    },
-    {
-        "url": "https://github.com/Commifreak/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/140912-kluthr/",
-        "bio": "Trying to make the world a bit better",
-        "icon": "https://raw.githubusercontent.com/Commifreak/unraid-plugins/master/pp.png",
-        "DonateLink": "https://www.paypal.me/robinkluth",
-        "DonateText": "If you like my work please consider donating.",
-        "WebPage": "https://kluthr.de",
-        "title": "KluthR's Repository",
-        "index": 159
-    },
-    {
-        "url": "https://github.com/maschhoff/docker",
-        "profile": "https://forums.unraid.net/profile/71048-knex666/",
-        "bio": "Building Unraid-Dockers for my environment and my projects to share them with you.\n  Most about Smart Home or automation and some more fancy stuff",
-        "icon": "https://avatars1.githubusercontent.com/u/4007829?s=460&u=379ce5191167d7e875f81bda8f205246a9e85dee&v=4",
-        "DonateLink": "https://www.buymeacoffee.com/maschhoff",
-        "DonateText": "If you like my work buy me a Pizza ;)",
-        "WebPage": "https://www.cmais.de",
-        "title": "knex666's Repository",
-        "index": 160
-    },
-    {
-        "url": "https://github.com/Kreuzbube88/heltemplates",
-        "profile": "https://forums.unraid.net/profile/288986-kreuzbube88/",
-        "bio": "No coding background \u2014 everything I build is created with AI (Claude). I design containers that include exactly what I need; they might be useful for you too.",
-        "icon": "https://github.com/Kreuzbube88/heltemplates/blob/main/ca_profil.jpg?raw=true",
-        "DonateLink": "https://paypal.me/kreuzbube88",
-        "DonateText": "Feel free to buy me a Coffee if you like my work.",
-        "title": "Kreuzbube88's Repository",
-        "index": 161
-    },
-    {
-        "url": "https://github.com/Krillsson/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285387-krillsson/",
-        "bio": "I'm primarily an App Developer but also a home server enthusiast. I've been tinkering on sys-API and Monitee for 10+ years now.",
-        "icon": "https://raw.githubusercontent.com/Krillsson/unraid-templates/refs/heads/main/ca_profile_avatar.png",
-        "DonateLink": "https://github.com/sponsors/Krillsson",
-        "DonateText": "Sponsorship will motivate me to continue working, adding features, improving performance and stability!",
-        "WebPage": "https://monitee.app/",
-        "title": "Krillsson's Repository",
-        "index": 162
-    },
-    {
-        "url": "https://github.com/kubedzero/unraid-community-apps-xml",
-        "profile": "https://forums.unraid.net/profile/12026-kubed_zero/",
-        "bio": "A curious Unraid plugin maintainer. Avoids unnecessary plugins.",
-        "icon": "https://raw.githubusercontent.com/kubedzero/unraid-community-apps-xml/main/GitHubAvatar.png",
-        "Forum": "https://forums.unraid.net/profile/12026-kubed_zero/",
-        "title": "kubed_zero's Repository",
-        "index": 163
-    },
-    {
-        "url": "https://github.com/kutzilla/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/129184-kutzilla/",
-        "bio": "Creating Unraid templates for my personal system. Maybe some of those templates are helpful for your purpose.",
-        "icon": "https://raw.githubusercontent.com/kutzilla/unraid-templates/master/images/avatar.jpg",
-        "title": "kutzilla's Repository",
-        "index": 164
-    },
-    {
-        "url": "https://github.com/L4stIdi0t/Unraid-template",
-        "profile": "https://forums.unraid.net/profile/122421-l4stidi0t/",
-        "bio": "Creating templates for containers which I am missing on CA.",
-        "icon": "https://github.com/l4stidi0t.png",
-        "Discord": "https://discord.com/invite/7QVzvjcDDM",
-        "title": "L4stIdi0t's Repository",
-        "index": 165
-    },
-    {
-        "url": "https://github.com/laromicas/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/172751-laromicas/",
-        "bio": "Passionate software developer constantly learning & improving. Experienced in Python, Java, NodeJS, Bash and any language I feel I need.",
-        "icon": "https://avatars.githubusercontent.com/u/2052864?v=4",
-        "DonateLink": "https://www.paypal.me/laromicas",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://github.com/laromicas",
-        "title": "laromicas' Repository",
-        "index": 166
-    },
-    {
-        "url": "https://github.com/Lazaros-Chalkidis/unraid-CA",
-        "profile": "https://forums.unraid.net/profile/170958-lazaros-chalkidis/",
-        "bio": "IT with 25+ years of experience. Specializing in WordPress security, malware removal, and servers management. Building open-source plugins for Unraid platform.",
-        "icon": "https://avatars.githubusercontent.com/u/263085199?v=4",
-        "title": "Lazaros Chalkidis' Repository",
-        "index": 167
-    },
-    {
-        "url": "https://github.com/LeonStoldt/Unraid-Community-Applications",
-        "profile": "https://forums.unraid.net/profile/170522-leonstoldt/",
-        "bio": "German Software Engineer",
-        "icon": "https://avatars.githubusercontent.com/u/31759512?v=4",
-        "DonateLink": "https://buymeacoffee.com/LeonStoldt",
-        "DonateText": "If you like my work please consider buying me a coffee.",
-        "WebPage": "https://leon-stoldt.de",
-        "title": "LeonStoldt's Repository",
-        "index": 168
-    },
-    {
-        "url": "https://github.com/linuxserver/templates",
-        "profile": null,
-        "bio": "We are a group of like minded enthusiasts from across the world who build and maintain the largest collection of Docker images on the web, and at our core are the principles behind Free and Open Source Software. Our primary goal is to provide easy-to-use and streamlined Docker images with clear and concise documentation.",
-        "icon": "https://github.com/linuxserver.png",
-        "DonateLink": "https://www.linuxserver.io/donate",
-        "DonateText": "Even the smallest donation from you will help us keep everything up and running so we can continue to provide our great services.",
-        "Forum": "https://discourse.linuxserver.io",
-        "Twitter": "https://twitter.com/linuxserverio",
-        "Discord": "https://discord.gg/YWrKVTn",
-        "WebPage": "https://www.linuxserver.io",
-        "title": "linuxserver's Repository",
-        "index": 169
-    },
-    {
-        "url": "https://github.com/iamlite/UnraidCA-GuppyFLO",
-        "profile": "https://forums.unraid.net/profile/275562-lite/",
-        "bio": "I break alot of stuff",
-        "icon": "https://github.com/iamlite/iamlite/blob/main/pfp.png?raw=true",
-        "title": "Lite's Repository",
-        "index": 170
-    },
-    {
-        "url": "https://github.com/ljm42/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/61877-ljm42/",
-        "bio": "These are my personal contributions to the community, not offical offerings by Lime Technologies",
-        "icon": "https://ipsassets.unraid.net/uploads/monthly_2020_12/Answer_to_Life.thumb.png.508f33beece2c22fb6dde4cf726a02f9.png",
-        "title": "ljm42's Repository",
-        "index": 171
-    },
-    {
-        "url": "https://github.com/llalon/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126527-llalon/",
-        "bio": "i write software and software accessories",
-        "icon": "https://raw.githubusercontent.com/llalon/unraid-templates/master/llalon/images/profile.jpg",
-        "title": "llalon's Repository",
-        "index": 172
-    },
-    {
-        "url": "https://github.com/lnxd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/114915-lnxd/",
-        "bio": "Unraid Fan. Timezone is GMT+11.",
-        "icon": "https://avatars.githubusercontent.com/u/48756329?s=500",
-        "DonateLink": "https://github.com/lnxd",
-        "DonateText": "If you like my work please consider donating.",
-        "title": "lnxd's Repository",
-        "index": 173
-    },
-    {
-        "url": "https://github.com/aglovewithoutlove/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/270452-logic_error/",
-        "bio": "Just trying to help out by adding missing templates for projects that I think are neat!",
-        "icon": "https://raw.githubusercontent.com/aglovewithoutlove/unraid-templates/refs/heads/main/profile.png",
-        "title": "logic_error's Repository",
-        "index": 174
-    },
-    {
-        "url": "https://github.com/lordfiSh/unraid-docker-images",
-        "profile": "https://forums.unraid.net/profile/92815-lordfish/",
-        "bio": "Unraid Docker images",
-        "icon": "https://raw.githubusercontent.com/lordfiSh/unraid-docker-images/main/images/avatar.jpg",
-        "DonateLink": "https://www.paypal.com/paypalme/imgeld",
-        "DonateText": "If you appreciate my work, then please consider buying me a beer :D",
-        "title": "lordfiSh's Repository",
-        "index": 175
-    },
-    {
-        "url": "https://github.com/lubeda/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/107977-lubeda/",
-        "bio": "I like home assistant and Unraid.",
-        "icon": "https://avatars.githubusercontent.com/u/17859549?s=60",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=FZDKSLQ46HJTU",
-        "DonateText": "If you like my work please consider donating.",
-        "title": "LuBeDa's Repository",
-        "index": 176
-    },
-    {
-        "url": "https://github.com/JamsRepos/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
-        "bio": "A collection of Unraid templates that I use and maintain.  I am always looking for feedback and suggestions for improvements and additional templates.",
-        "icon": "https://avatars.githubusercontent.com/u/1347620?v=4",
-        "DonateLink": "https://github.com/sponsors/JamsRepos",
-        "DonateText": "Feeling generous?  Consider sponsoring me on GitHub!",
-        "Forum": "https://github.com/JamsRepos/Unraid-Templates/issues",
-        "WebPage": "https://github.com/JamsRepos/Unraid-Templates",
-        "title": "LubricantJam's Repository",
-        "index": 177
-    },
-    {
-        "url": "https://github.com/luigi311/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/72460-luigi311/",
-        "bio": "I am a software developer with a focus on creating and supporting open source projects with a focus on media related projects.",
-        "WebPage": "https://github.com/luigi311",
-        "title": "Luigi311's Repository",
-        "index": 178
-    },
-    {
-        "url": "https://github.com/logandwaters/Plug-and-Play-Docker",
-        "profile": "https://forums.unraid.net/profile/281787-lwater/",
-        "bio": "I mostly create custom templates for other software, following my Plug-and-Play (PnP) rules\u2014designed to embody the simplicity Unraid apps should offer, with easy installation and minimal tinkering. While my focus is on templates, I also develop my own software occasionally. My goal is to streamline setup so users enjoy hassle-free experiences.",
-        "icon": "https://raw.githubusercontent.com/logandwaters/Plug-and-Play-Docker/refs/heads/main/profile/profile_picture.jpg",
-        "DonateLink": "https://www.paypal.me/logandwateres",
-        "DonateText": "I create software, templates, and tools\u2014both for my projects and to complement others' work. If you find them useful, please consider donating to support my efforts. While I build templates for other software, remember to also support the original creators of the tools you enjoy!",
-        "title": "lwater's Repository",
-        "index": 179
-    },
-    {
-        "url": "https://github.com/m0ngr31/unraid_ca",
-        "profile": "https://forums.unraid.net/profile/75617-m0ngr31/",
-        "bio": "Creating apps as I see a need for them.",
-        "icon": "https://avatars.githubusercontent.com/u/1045977?v=4",
-        "Forum": "https://forums.unraid.net/topic/149018-support-m0ngr31-dockers/",
-        "WebPage": "https://github.com/m0ngr31",
-        "title": "m0ngr31's Repository",
-        "index": 180
-    },
-    {
-        "url": "https://github.com/Oratorian/unraid-templates",
-        "profile": null,
-        "bio": "Open-source projects from Oratorian. Currently maintaining emby-watchparty, a synchronized watch-party frontend for Emby media servers that lets you watch videos with friends in real time without giving them Emby accounts. The Emby server stays on your local network, the watch party app proxies HLS streams to guests, and play/pause/seek stay synchronized across every viewer. For support, please use the linked Unraid forum thread (preferred) or open an issue on GitHub.",
-        "icon": "https://raw.githubusercontent.com/Oratorian/emby-watchparty/main/static/favicon.ico",
-        "DonateLink": "https://ko-fi.com/jedziah",
-        "DonateText": "Support development on Ko-fi",
-        "Forum": "https://forums.unraid.net/topic/198376-support-emby-watchparty-watch-party-for-emby-synchronized-playback/",
-        "Discord": "https://discord.gg/RWUpxq9xsA",
-        "WebPage": "https://github.com/Oratorian",
-        "title": "Mahesvara's Toolshed",
-        "index": 181
-    },
-    {
-        "url": "https://github.com/Mainfrezzer/UnRaid-Templates/",
-        "profile": "https://forums.unraid.net/profile/201895-mainfrezzer/",
-        "bio": "I like to tinker around to solve my problems.",
-        "icon": "https://raw.githubusercontent.com/Mainfrezzer/UnRaid-Templates/main/icon/avatar.png",
-        "title": "Mainfrezzer's Repository",
-        "index": 182
-    },
-    {
-        "url": "https://github.com/mak-cs/unraid",
-        "profile": "https://forums.unraid.net/profile/269540-mak-cs/",
-        "bio": "I create templates of Docker containers to solve my Unraid requirements. If you find them useful, feel free to use them.",
-        "icon": "https://raw.githubusercontent.com/mak-cs/unraid/master/icons/mak.png",
-        "DonateLink": "https://paypal.me/makcs",
-        "DonateText": "If you like my work, please consider making a donation.",
-        "title": "MAK-CS' Repository",
-        "index": 183
-    },
-    {
-        "url": "https://github.com/manuel-rw/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/138040-manrw/",
-        "bio": "C# Software Engineer from Switzerland, loves to code and watch Anime. Contributes to open source projects.",
-        "icon": "https://github.com/manuel-rw.png",
-        "DonateLink": "https://ko-fi.com/manicraft1001",
-        "DonateText": "Please donate me a coffee if you like my work!",
-        "Discord": "https://discord.gg/hRHZ3q3VDX",
-        "title": "manrw's Repository",
-        "index": 184
-    },
-    {
-        "url": "https://github.com/mmartial/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/15ho4534-martial/",
-        "bio": "Enthusiastic self-hoster, Researcher, Developer, with a passion for teaching (see my blog \ud83d\ude0a) ... a geekier profile \ud83d\ude80",
-        "icon": "https://raw.githubusercontent.com/mmartial/unraid-templates/master/templates/assets/MM.jpg",
-        "WebPage": "https://www.gkr.one/",
-        "title": "martial's Repository",
-        "index": 185
-    },
-    {
-        "url": "https://github.com/marzel1/docker-templates",
-        "profile": "https://forums.unraid.net/profile/117249-marzel/",
-        "bio": "Hobbyist self-hoster.",
-        "icon": "https://raw.githubusercontent.com/marzel1/docker-templates/main/marzel/img/marzel.jpg",
-        "Forum": "https://forums.unraid.net/topic/107813-support-marzel-remotely/",
-        "WebPage": "https://forums.unraid.net/profile/117249-marzel/",
-        "title": "Marzel's Repository",
-        "index": 186
-    },
-    {
-        "url": "https://github.com/masterwishx/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/107418-masterwishx/",
-        "bio": "Creator of a few Unraid Templates.",
-        "icon": "https://github.com/masterwishx.png",
-        "title": "Masterwishx's Repository",
-        "index": 187
-    },
-    {
-        "url": "https://github.com/MattFaz/unraid_templates/",
-        "profile": "https://forums.unraid.net/profile/76145-mattfaz/",
-        "bio": "Creating DOcker Containers that I personally use.",
-        "icon": "https://raw.githubusercontent.com/MattFaz/unraid_templates/main/images/profile.png",
-        "Forum": "https://forums.unraid.net/topic/144385-support-mattfaz-repo/",
-        "title": "MattFaz's Repository",
-        "index": 188
-    },
-    {
-        "url": "https://github.com/MattyStacks/docker-templates",
-        "profile": "https://forums.unraid.net/profile/9036-mattystacks/",
-        "bio": "MattyStacks' Docker Templates for Unraid",
-        "icon": "https://raw.githubusercontent.com/MattyStacks/docker-templates/main/MattyStacks/images/MattyStacks.jpg",
-        "title": "MattyStacks's Repository",
-        "index": 189
-    },
-    {
-        "url": "https://github.com/Mavrag/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/111982-mavrag/",
-        "bio": "I create Docker templates for Unraid.",
-        "icon": "https://raw.githubusercontent.com/mavrag/unraid-templates/master/mavrag_logo.png",
-        "DonateLink": "https://paypal.me/mavrag",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Mavrag's Repository",
-        "index": 190
-    },
-    {
-        "url": "https://github.com/mcreekmore/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/216090-mcreekmore/",
-        "bio": "Filling gaps wherever I find them :)",
-        "icon": "https://avatars.githubusercontent.com/u/48491595?v=4",
-        "DonateLink": "https://www.paypal.com/donate/?business=PNX6CA3TXGT2S&no_recurring=0&currency_code=USD",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "mcreekmore's Repository",
-        "index": 191
-    },
-    {
-        "url": "https://github.com/silkyclouds/unraid-disk-talkers",
-        "profile": null,
-        "bio": "Building stuff I need.",
-        "icon": "https://github.com/silkyclouds.png",
-        "title": "meaning's Repository",
-        "index": 192
-    },
-    {
-        "url": "https://github.com/medzin/docker-templates",
-        "profile": "https://forums.unraid.net/profile/293048-medzin/",
-        "bio": "Hobbyist and home lab enthusiast creating Docker templates to simplify self-hosted deployments for the community.",
-        "icon": "https://raw.githubusercontent.com/medzin/docker-templates/main/images/profile-icon.png",
-        "Twitter": "https://x.com/m3d21n",
-        "title": "medzin's Repository",
-        "index": 193
-    },
-    {
-        "url": "https://github.com/Memtly/Memtly.Unraid",
-        "profile": null,
-        "bio": "Software developer by day, software developer by night...",
-        "icon": "https://raw.githubusercontent.com/Memtly/Memtly.Assets/master/Logos/Community/Memtly.png",
-        "DonateLink": "https://buymeacoffee.com/memtly",
-        "DonateText": "BuyMeACoffee",
-        "WebPage": "https://github.com/Memtly",
-        "title": "Memtly's Repository",
-        "index": 194
-    },
-    {
-        "url": "https://github.com/mgutt/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/94359-mgutt",
-        "bio": "German Developer",
-        "icon": "https://raw.githubusercontent.com/mgutt/unraid-docker-templates/main/mgutt/images/avatar.jpg",
-        "DonateLink": "https://www.paypal.me/marcgutt",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://gutt.it/",
-        "title": "mgutt's Repository",
-        "index": 195
-    },
-    {
-        "url": "https://github.com/MiranoVerhoef/Unraid-Mirano",
-        "profile": "https://forums.unraid.net/profile/96734-mirano/",
-        "bio": "Helping out the community by creating CA Templates, whereas no one has made one yet.",
-        "icon": "https://raw.githubusercontent.com/MiranoVerhoef/Unraid-Mirano/main/ca_profile/Avatar.jpeg",
-        "Forum": "https://forums.unraid.net/topic/150080-support-mirano-docker-containers/",
-        "WebPage": "https://github.com/MiranoVerhoef/Unraid-Mirano",
-        "title": "Mirano's Repository",
-        "index": 196
-    },
-    {
-        "url": "https://github.com/mmenanno/unraid-templates",
-        "profile": null,
-        "bio": "A small, hand-maintained collection of Unraid Community Applications templates for containers I build and publish under github.com/mmenanno. Each app has its own upstream GitHub repo where development, releases, and support happen; the template's Support button links there, and that's the right place to file bugs or request features. New apps are added as I publish them.",
-        "icon": "https://github.com/mmenanno.png",
-        "DonateLink": "https://buymeacoffee.com/mmenanno",
-        "DonateText": "Buy me a coffee",
-        "WebPage": "https://github.com/mmenanno/unraid-templates",
-        "title": "mmenanno's Repository",
-        "index": 197
-    },
-    {
-        "url": "https://github.com/MountainGod2/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/167420-mrslaw/",
-        "bio": "Unraid enthusiast and IBRACORP team member. Join the Discord!",
-        "icon": "https://raw.githubusercontent.com/MountainGod2/unraid-templates/main/MG_Logo.png",
-        "DonateLink": "https://paypal.me/ibracorp",
-        "DonateText": "If you like their work, please consider donating.",
-        "Discord": "https://discord.gg/VWAG7rZ",
-        "WebPage": "https://ibracorp.io",
-        "title": "mrslaw's Repository",
-        "index": 198
-    },
-    {
-        "url": "https://github.com/n8detar/docker-templates",
-        "profile": "https://forums.unraid.net/profile/104222-ndetar/",
-        "bio": "I am not really a developer, I just made someone elses docker container available to others in the Unraid Community, I hope it helps!",
-        "icon": "https://raw.githubusercontent.com/n8detar/docker-templates/master/n8detar/images/avatar.png",
-        "title": "ndetar's Repository",
-        "index": 199
-    },
-    {
-        "url": "https://github.com/NightMeer/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/191921-nightmeer/",
-        "bio": "Creating Containers and Plugins.",
-        "icon": "https://raw.githubusercontent.com/NightMeer/Unraid-Docker-Templates/main/images/avatar.png",
-        "DonateLink": "https://paypal.me/nightmeer",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "NightMeer's Repository",
-        "index": 200
-    },
-    {
-        "url": "https://github.com/ninthwalker/docker-templates",
-        "profile": "https://forums.unraid.net/profile/9420-ninthwalker/",
-        "bio": "Creating bots, scripts, dockers and other small projects",
-        "icon": "https://raw.githubusercontent.com/ninthwalker/github/main/img/brentsflix/bfx.png",
-        "DonateLink": "https://github.com/sponsors/ninthwalker",
-        "DonateText": "Donations are definitely not required, but much appreciated!",
-        "title": "ninthwalker's Repository",
-        "index": 201
-    },
-    {
-        "url": "https://github.com/nodiaque/unraid_template",
-        "profile": "https://forums.unraid.net/profile/147860-nodiaque/",
-        "bio": "Creating Containers to benefit the Unraid Community",
-        "icon": "https://raw.githubusercontent.com/nodiaque/unraid_template/master/nodiaque/images/avatar.png",
-        "DonateLink": "https://paypal.me/nodiaque",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Nodiaque's Repository",
-        "index": 202
-    },
-    {
-        "url": "https://github.com/nulcraft/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/88507-nulcraft/",
-        "bio": "Building self-hosted tools focused on simplicity and automation. The goal is always the same: less manual work, more control, and no unnecessary complexity. I believe good software should get out of your way and just work, letting you focus on what actually matters instead of managing the tools themselves.",
-        "icon": "https://github.com/nulcraft.png",
-        "title": "nulcraft's Repository",
-        "index": 203
-    },
-    {
-        "url": "https://github.com/photostructure/unraid-template",
-        "profile": "https://forums.unraid.net/profile/116201-mrm/",
-        "shortName": "PhotoStructure",
-        "bio": "Building PhotoStructure, your new home for your family's photos and videos.",
-        "icon": "https://photostructure.com/img/2020/08/mrm-256w.jpg",
-        "DonateLink": "https://photostructure.com/pricing",
-        "DonateText": "PhotoStructure is completely subscriber-supported!",
-        "Reddit": "https://reddit.com/r/PhotoStructure/",
-        "Twitter": "https://twitter.com/PhotoStructure",
-        "Discord": "https://discord.gg/gU9h8uQTYw",
-        "WebPage": "https://photostructure.com",
-        "title": "Official PhotoStructure Repository",
-        "index": 204
-    },
-    {
-        "url": "https://github.com/unraid/language-templates",
-        "profile": null,
-        "shortName": "Unraid",
-        "bio": "Lime Technology Inc is the maker of Unraid OS. Unraid is an OS for personal and small business use that brings enterprise-class features letting you configure your computer systems to maximize performance and capacity using any combination of applications, VMs, storage devices, and hardware.",
-        "icon": "https://craftassets.unraid.net/uploads/Social-Circle-@2x.png",
-        "Facebook": "https://www.facebook.com/UnraidOfficial",
-        "Reddit": "https://www.reddit.com/r/unRAID/",
-        "Forum": "https://forums.unraid.net/",
-        "Twitter": "https://twitter.com/UnraidOfficial",
-        "WebPage": "https://unraid.net/",
-        "title": "Official Unraid Repository",
-        "index": 205
-    },
-    {
-        "url": "https://github.com/Organizr/docker-organizr",
-        "profile": null,
-        "bio": "Creating official Docker images for the Organizr application.",
-        "icon": "https://raw.githubusercontent.com/causefx/Organizr/v2-master/plugins/images/organizr/logo-no-border.png",
-        "DonateLink": "https://paypal.me/causefx",
-        "DonateText": "If you like my work please consider Donating.",
-        "Discord": "https://organizr.app/discord",
-        "WebPage": "https://organizr.app/",
-        "title": "Organizr Repository",
-        "index": 206
-    },
-    {
-        "url": "https://github.com/oromis995/UnraidKoboldCpp",
-        "profile": "https://forums.unraid.net/profile/108450-oromis95/",
-        "bio": "AI Software Engineer, if you seek me for non-business reasons, Discord is the best place to reach me, where I'm oromis95.",
-        "icon": "https://avatars.githubusercontent.com/u/54419741?s=400&u=63f1e75cc721abe46f6af39936eb9670a00aed64&v=4",
-        "title": "oromis95's Repository",
-        "index": 207
-    },
-    {
-        "url": "https://github.com/Pa7rickStar/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/288616-pa7rickstar/",
-        "bio": "Creating Docker containers from the comfort of my pineapple. I always try to make containers which work out of the box and use official sources as much as possible.",
-        "icon": "https://raw.githubusercontent.com/Pa7rickStar/unraid_templates/refs/heads/main/images/avatar.png",
-        "DonateLink": "https://buymeacoffee.com/pa7rickstar",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Pa7ricstar's Repository",
-        "index": 208
-    },
-    {
-        "url": "https://github.com/paulpoco/docker-templates",
-        "profile": "https://forums.unraid.net/profile/69794-paul_ber/",
-        "bio": "Just adapting existing DockerHub images and doing the Templates for Unraid",
-        "icon": "https://raw.githubusercontent.com/paulpoco/docker-templates/master/paulpoco/images/pjbwidgets_web_hi_res_512.png",
-        "title": "Paul_Ber's Repository",
-        "index": 209
-    },
-    {
-        "url": "https://github.com/imTHAI/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/117577-pbear/",
-        "bio": "Mai pen rai.",
-        "icon": "https://raw.githubusercontent.com/imTHAI/unraid-templates/main/me_bw.png",
-        "title": "pbear's Repository",
-        "index": 210
-    },
-    {
-        "url": "https://github.com/PerpetualSoftware/unraid-templates",
-        "profile": null,
-        "bio": "Perpetual Software ships local-first developer tools that respect your data and run on hardware you control. This repository holds our Unraid Community Applications templates.",
-        "icon": "https://raw.githubusercontent.com/PerpetualSoftware/unraid-templates/main/icon.png",
-        "Forum": "https://forums.unraid.net/topic/198646-support-pad-local-first-project-management-for-developers-and-ai-agents/",
-        "WebPage": "https://perpetualsoftware.org",
-        "title": "Perpetual Software's Repository",
-        "index": 211
-    },
-    {
-        "url": "https://github.com/petersem/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/240191-petersem/",
-        "bio": "I.T Architect, Coder, geek, dad, rev-head, sci-fi guy, and lover of great wines and whiskey. ;)",
-        "icon": "https://avatars.githubusercontent.com/u/1418289?v=4",
-        "DonateLink": "https://www.paypal.com/paypalme/thanksmp",
-        "DonateText": "If you like my work please consider Donating.",
-        "Discord": "https://discord.gg/TcnEkMEf9J",
-        "title": "petersem's Repository",
-        "index": 212
-    },
-    {
-        "url": "https://github.com/Peuuuur-Noel/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/155305-peuuuur-noel/",
-        "bio": "Blue marmot.",
-        "icon": "https://github.com/peuuuur-noel.png",
-        "title": "Peuuuur Noel's Repository",
-        "index": 213
-    },
-    {
-        "url": "https://github.com/Phalcode/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/266495-phalcode/",
-        "bio": "small software development team, from germany, consisting of 2 people, publishing their applications.",
-        "icon": "https://github.com/phalcode.png",
-        "DonateLink": "https://phalco.de/support-us",
-        "DonateText": "If you like our work please consider donating.",
-        "Reddit": "https://reddit.com/r/phalcode",
-        "Discord": "https://discord.gg/NEdNen2dSu",
-        "title": "phalcode's Repository",
-        "index": 214
-    },
-    {
-        "url": "https://github.com/Phil-Barker/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/211519-philbarker/",
-        "bio": "Just an ex-developer, now CTO, who loves tinkering with Unraid in his spare time.",
-        "icon": "https://phil-barker.com/assets/img/1.png",
-        "title": "PhilBarker's Repository",
-        "index": 215
-    },
-    {
-        "url": "https://github.com/pierot/unraid-ca-apps",
-        "profile": "https://forums.unraid.net/profile/121203-pieterm/",
-        "bio": "Building, automating, tinkering.",
-        "icon": "https://avatars.githubusercontent.com/u/46622?v=4",
-        "WebPage": "https://noort.be",
-        "title": "pieterm's Repository",
-        "index": 216
-    },
-    {
-        "url": "https://github.com/PikkonMG/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/75476-pikkonmg/",
-        "bio": "Creating Docker containers and templates for Unraid",
-        "icon": "https://raw.githubusercontent.com/PikkonMG/unraid-docker-templates/main/templates/img/faqfirebase_512x512.png",
-        "DonateLink": "https://paypal.me/HighlandJewls",
-        "DonateText": "Templates are free, coffee is optional",
-        "title": "PikkonMG's Repository",
-        "index": 217
-    },
-    {
-        "url": "https://github.com/noinip/container-templates",
-        "profile": "https://forums.unraid.net/profile/10946-pinion/",
-        "bio": "I started when Docker came on the scene with Unraid some 7 or so years ago. CherryMusic and pyTiVo are my main two and I plan to revisit them now in 2021/22.",
-        "icon": "https://forums.unraid.net/uploads/monthly_2020_11/ring-and-pinion-set-alt-v2.jpg.67cc28c50f97467b1f4369c7e8e9b297.jpg",
-        "title": "pinion's Repository",
-        "index": 218
-    },
-    {
-        "url": "https://github.com/PlazzmiK/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/268068-plazzmik/",
-        "bio": "Checking and adding docker containers to Unraid that I personaly use...",
-        "icon": "https://raw.githubusercontent.com/PlazzmiK/unraid_templates/main/images/profile.png",
-        "DonateLink": "https://www.Teunis.be",
-        "DonateText": "Check out my other stuff.",
-        "WebPage": "https://www.Teunis.be",
-        "title": "Plazzmik's Repository",
-        "index": 219
-    },
-    {
-        "url": "https://github.com/PTRFRLL/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/75102-ptrfrll",
-        "bio": "Giving back to the Unraid community, one application at a time.",
-        "icon": "https://raw.githubusercontent.com/PTRFRLL/unraid-templates/master/assets/icon.png",
-        "DonateLink": "https://www.paypal.me/ptrfrll",
-        "DonateText": "Buy me a coffee/beer",
-        "WebPage": "https://github.com/PTRFRLL",
-        "title": "PTRFRLL's Repository",
-        "index": 220
-    },
-    {
-        "url": "https://github.com/ds-sebastian/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/238004-pureelectricity/",
-        "bio": "Data Scientist and Sys admin cosplayer. I like to self-host",
-        "icon": "https://media.invisioncic.com/u329766/monthly_2025_01/majora.jpg.5c3594f3f16f52ae462e3653f4c5a760.jpg",
-        "WebPage": "https://github.com/ds-sebastian",
-        "title": "pureelectricity's Repository",
-        "index": 221
-    },
-    {
-        "url": "https://github.com/pyrater/docker-templates",
-        "profile": "https://forums.unraid.net/profile/14118-pyrater/",
-        "bio": "Lets do this.",
-        "icon": "https://raw.githubusercontent.com/pyrater/docker-templates/main/pyrater.png",
-        "title": "pyrater's Repository",
-        "index": 222
-    },
-    {
-        "url": "https://github.com/gjhami/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281298-raidingunraid/",
-        "bio": "Penetration tester and researcher interested in making containers for the security conscious.",
-        "icon": "https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg",
-        "title": "raidingUnraid's Repository",
-        "index": 223
-    },
-    {
-        "url": "https://github.com/RandomNinjaAtk/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/9890-randomninjaatk/",
-        "bio": "Integrating scripts to enhance existing docker containers functionality.",
-        "icon": "https://avatars0.githubusercontent.com/u/8386416",
-        "DonateLink": "https://github.com/sponsors/RandomNinjaAtk",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "randomninjaatk's Repository",
-        "index": 224
-    },
-    {
-        "url": "https://github.com/RazorSiM/docker-templates",
-        "profile": "https://forums.unraid.net/profile/84655-raz/",
-        "bio": "Random Docker containers template for applications I like.",
-        "icon": "https://github.com/RazorSiM/docker-templates/raw/master/razLogo.png",
-        "DonateLink": "https://paypal.me/simonecolabufalo",
-        "DonateText": "If you want to have a beer with me, you're always welcome :)",
-        "Discord": "https://discord.gg/Mn2Ty3y",
-        "WebPage": "https://raz.wtf",
-        "title": "raz's Repository",
-        "index": 225
-    },
-    {
-        "url": "https://github.com/redvex2460/docker-templates",
-        "profile": "https://forums.unraid.net/profile/128113-redvex/",
-        "bio": "Creating Containers and Plugins with the intention to make them as easy as possible to install and use.",
-        "icon": "https://raw.githubusercontent.com/redvex2460/docker-templates/main/redvex/images/avatar.jpg",
-        "DonateLink": "https://paypal.me/RedVex2460Gaming",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "RedVex's Repository",
-        "index": 226
-    },
-    {
-        "url": "https://github.com/rix1337/docker-templates",
-        "profile": "https://forums.unraid.net/profile/67339-rix/",
-        "bio": "I love automation. What is not there, I create myself. I only answer support queries on GitHub.",
-        "icon": "https://github.com/rix1337.png",
-        "DonateLink": "https://github.com/users/rix1337/sponsorship",
-        "DonateText": "Sponsor me if you like my work!",
-        "title": "rix's Repository",
-        "index": 227
-    },
-    {
-        "url": "https://github.com/robotfishe/robotfishe-unraid-apps",
-        "profile": "https://forums.unraid.net/profile/204504-robotfishe/",
-        "bio": "Contributing anything I cobble together for my own Unraid use in case it might help someone else.",
-        "title": "robotfishe's Repository",
-        "index": 228
-    },
-    {
-        "url": "https://github.com/Data-Monkey/docker-templates",
-        "profile": "https://forums.unraid.net/profile/62021-roland/",
-        "bio": "I am not attempting to create containers, but I have built a few templates to make life a little easier. If you are looking for details on the containers, please check out the individual DockerHub pages.\n    There is usually also a support thread linked in the respectiuve template.",
-        "icon": "https://ipsassets.unraid.net/uploads/monthly_2017_02/DataMonkey.gif.2e58e2d34570035409850b750e2b4ae2.gif",
-        "title": "Roland's Repository",
-        "index": 229
-    },
-    {
-        "url": "https://github.com/rroller/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/75343-runraid/",
-        "bio": "Adding missing containers as I find and need them.",
-        "icon": "https://i.imgur.com/ZjNRfo3.png",
-        "WebPage": "https://ronnieroller.com",
-        "title": "runraid's Repository",
-        "index": 230
-    },
-    {
-        "url": "https://github.com/catapultcase/Unraid_CommunityApplications",
-        "profile": "https://forums.unraid.net/profile/83669-rusty6285/",
-        "bio": "Hardware enthusiast and developer of JunctionRelay, an open source platform for real-time device and sensor coordination.",
-        "icon": "https://catapultcase.com/wp-content/uploads/2025/05/jr_logo-scaled.png",
-        "DonateLink": "https://buymeacoffee.com/catapultcase",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Rusty6285's Repository",
-        "index": 231
-    },
-    {
-        "url": "https://github.com/desertwitch/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/115350-rysz/",
-        "bio": "Hi, I'm Rysz - a data storage and open source enthusiast from Europe.\n    I mainly focus on bringing software to the Unraid OS ecosystem, with plugins now enhancing more than 20,000 servers.\n    I'm passionate about contributing to open source projects, the Go programming language and working with UPS devices.",
-        "icon": "https://raw.githubusercontent.com/desertwitch/unraid-plugins/main/avatar.jpg",
-        "WebPage": "https://desertwitch.github.io/unraid-projects/",
-        "title": "Rysz's Repository",
-        "index": 232
-    },
-    {
-        "url": "https://github.com/Sander0542/docker-templates",
-        "profile": "https://forums.unraid.net/profile/98342-sander0542/",
-        "bio": "Developer who likes to create usefull tools and share them with the world.",
-        "icon": "https://github.com/Sander0542.png",
-        "DonateLink": "https://github.com/sponsors/Sander0542",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Sander0542's Repository",
-        "index": 233
-    },
-    {
-        "url": "https://github.com/ivaxor/unraid-ca-docker-templates",
-        "profile": "https://forums.unraid.net/profile/147445-saskiuhia/",
-        "bio": "We are a few man that know how to use a computer at max. Mainly we are developing products for ourselfs. But sometimes they come to a big world of open-source.",
-        "icon": "https://raw.githubusercontent.com/ivaxor/press-assets-information/master/icons/logo.png",
-        "DonateLink": "https://github.com/sponsors/ivaxor",
-        "DonateText": "Sponsor me if you like my work!",
-        "title": "saskiuhia's Repository",
-        "index": 234
-    },
-    {
-        "url": "https://github.com/Schaka/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/243152-schaka/",
-        "bio": "Creating a variety of useful self-hosted apps.",
-        "icon": "https://raw.githubusercontent.com/Schaka/unraid-templates/main/schaka.jpg",
-        "WebPage": "https://github.com/Schaka",
-        "title": "Schaka's Repository",
-        "index": 235
-    },
-    {
-        "url": "https://github.com/sceather/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/87682-scootter/",
-        "bio": "I couldn't find some Unraid Templates so I created them myself. Definitely not an expert but maybe these can help someone else.",
-        "icon": "https://raw.githubusercontent.com/sceather/unraid-templates/refs/heads/main/images/scootter.png",
-        "title": "Scootter's Repository",
-        "index": 236
-    },
-    {
-        "url": "https://github.com/Sdub76/unraid_docker_templates",
-        "profile": "https://forums.unraid.net/profile/113369-sdub",
-        "bio": "My template respository to fill gaps I find in the CA store",
-        "icon": "https://avatars0.githubusercontent.com/u/11237911",
-        "DonateLink": "https://paypal.me/ScottWaun",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://github.com/Sdub76/unraid_docker_templates",
-        "title": "sdub's Repository",
-        "index": 237
-    },
-    {
-        "url": "https://github.com/selfhosters/unRAID-CA-templates",
-        "profile": null,
-        "shortName": "Selfhosters",
-        "bio": "A bunch of happy folks adding what the community want, to give them choice, for free. Request stuff on our github https://github.com/selfhosters/Unraid-CA-templates",
-        "icon": "https://github.com/selfhosters.png",
-        "Forum": "https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/",
-        "Discord": "https://discord.gg/qWPbc8R",
-        "WebPage": "https://selfhosters.net/",
-        "title": "Selfhosters Unraid Discord Repository",
-        "index": 238
-    },
-    {
-        "url": "https://github.com/xshatterx/Seraphys",
-        "profile": "https://forums.unraid.net/profile/275245-seraphys/",
-        "bio": "Docker Master",
-        "icon": "https://github.com/xshatterx.png",
-        "title": "Seraphys' Repository",
-        "index": 239
-    },
-    {
-        "url": "https://github.com/seriousm4x/unraid-community-apps",
-        "profile": "https://forums.unraid.net/profile/246841-seriousm4x/",
-        "bio": "\ud83c\udfa5 Audio visual media designer (cutter and camera guy) from Germany\n        \ud83e\udd16 Very interested in Open Source AI projects like whisper\n        \ud83d\udd25 Arch (btw) for both, programming and video editing in Davinci Resolve\n        \u2615 Coffee enjoyer",
-        "icon": "https://avatars.githubusercontent.com/u/23456686?v=4",
-        "DonateLink": "https://github.com/seriousm4x#want-to-buy-me-a--",
-        "DonateText": "Want to support my work? Buy me a coffee on ko-fi or become a Github Sponsor.",
-        "Reddit": "https://www.reddit.com/user/SeriousM4x",
-        "Twitter": "https://twitter.com/SeriousM4x",
-        "title": "seriousm4x's Repository",
-        "index": 240
-    },
-    {
-        "url": "https://github.com/sgraaf/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/119190-sgraaf/",
-        "bio": "I create templates for any Docker containers that I use that are not yet\n    listed on CA.",
-        "icon": "https://github.com/sgraaf.png",
-        "DonateLink": "https://www.paypal.me/sgraaf2",
-        "DonateText": "Help support my work by buying me a coffee or a beer",
-        "title": "sgraaf's Repository",
-        "index": 241
-    },
-    {
-        "url": "https://github.com/ShaneIsrael/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/168827-shane-israel/",
-        "bio": "I just like creating useful software to that solves my own problems, and then sharing it with everyone else.",
-        "icon": "https://raw.githubusercontent.com/shaneisrael/unraid-templates/master/images/avatar.png",
-        "DonateLink": "https://buymeacoffee.com/shaneisrael",
-        "DonateText": "If you like my work please consider buying me a coffee. Thank you!",
-        "title": "Shane Israel's Repository",
-        "index": 242
-    },
-    {
-        "url": "https://github.com/m3ue/m3u-editor",
-        "profile": "https://forums.unraid.net/profile/292018-shparkison/",
-        "bio": "Official m3u editor application maintained by sparkison.\n    Full featured IPTV playlist editor and proxy server.",
-        "icon": "https://raw.githubusercontent.com/sparkison/m3u-editor/refs/heads/master/public/logo.png",
-        "DonateLink": "https://ko-fi.com/sparkison",
-        "DonateText": "If you like my work please consider Donating.",
-        "Discord": "https://discord.gg/rS3abJ5dz7",
-        "title": "shparikson's Repository",
-        "index": 243
-    },
-    {
-        "url": "https://github.com/simonjenny/unraid",
-        "profile": "https://forums.unraid.net/profile/122229-simon-jenny/",
-        "bio": "Swiss Developer",
-        "icon": "https://raw.githubusercontent.com/simonjenny/unraid/main/avatar.jpg",
-        "WebPage": "https://simonjenny.dev",
-        "title": "Simon Jenny's Repository",
-        "index": 244
-    },
-    {
-        "url": "https://github.com/Skylinar/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/109199-skylinar/",
-        "bio": "I maintain templates for some of my favorite services and hope you'll find them enjoyable too.",
-        "icon": "https://raw.githubusercontent.com/Skylinar/unraid_templates/refs/heads/main/images/profile.jpeg?raw=true",
-        "DonateLink": "https://ko-fi.com/skylinar",
-        "DonateText": "If you find my work helpful, consider buying me a coffee!",
-        "Forum": "https://forums.unraid.net/topic/193655-support-skylinars-repository/",
-        "WebPage": "https://github.com/Skylinar",
-        "title": "Skylinar's Repository",
-        "index": 245
-    },
-    {
-        "url": "https://github.com/slamanna212/UnraidTemplates",
-        "profile": "https://forums.unraid.net/profile/106550-slamanna212/",
-        "bio": "Niche Docker containers are my jam!",
-        "icon": "https://github.com/slamanna212/UnraidTemplates/blob/main/avatar.png?raw=true",
-        "title": "slamanna212's Repository",
-        "index": 246
-    },
-    {
-        "url": "https://github.com/MasterEvarior/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/140790-smithynithy/",
-        "bio": "Just doing my part!",
-        "icon": "https://avatars.githubusercontent.com/u/36074738?v=4",
-        "title": "SmithyNithy's Repository",
-        "index": 247
-    },
-    {
-        "url": "https://github.com/smoores-dev/storyteller-unraid",
-        "profile": "https://forums.unraid.net/profile/144985-smoores/",
-        "bio": "Creator and maintainer of Storyteller, a self-hosted platform for aligning ebooks and audiobooks.",
-        "icon": "https://gravatar.com/avatar/42222c68f7582de365c2a11603ebf9d3",
-        "DonateLink": "https://opencollective.com/storyteller",
-        "DonateText": "You can support future Storyteller development by donating through Open Collective!",
-        "title": "smoores' Repository",
-        "index": 248
-    },
-    {
-        "url": "https://github.com/Kometa-Team/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/198915-sohjiro/",
-        "bio": "Author of Kometa.",
-        "icon": "https://avatars.githubusercontent.com/u/166754869",
-        "DonateLink": "https://github.com/sponsors/meisnate12",
-        "DonateText": "Even the smallest donation from you will help keep Kometa updated with new fixes and features.",
-        "Reddit": "https://www.reddit.com/r/Kometa/",
-        "Forum": "https://github.com/Kometa-Team/Kometa/issues/new/choose",
-        "Discord": "https://kometa.wiki/en/latest/discord/",
-        "WebPage": "https://kometa.wiki",
-        "title": "Sohjiro's Repository",
-        "index": 249
-    },
-    {
-        "url": "https://github.com/soitora/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/282682-soitora/",
-        "bio": "I am adding Unraid Community Application templates for containers I have set up and not found in the Application store.",
-        "icon": "https://github.com/soitora.png",
-        "DonateLink": "https://ko-fi.com/soitora",
-        "DonateText": "If you like my work please consider Donating.",
-        "Forum": "https://forums.unraid.net/topic/192298-support-soitoras-unraid-templates/",
-        "title": "Soitora's Repository",
-        "index": 250
-    },
-    {
-        "url": "https://github.com/soonic6/unraid-templates-ca",
-        "profile": "https://forums.unraid.net/profile/94002-sonic6/",
-        "bio": "simple Unraid templates",
-        "icon": "https://raw.githubusercontent.com/soonic6/unraid-templates-ca/main/soonic6/images/image.png",
-        "title": "sonic6's Repository",
-        "index": 251
-    },
-    {
-        "url": "https://github.com/Squidly271/plugin-repository",
-        "profile": "https://forums.unraid.net/profile/10290-squid/",
-        "bio": "Unraid fan and the author and maintainer of various plugins for Unraid including **Community Applications** and **Fix Common Problems**, along with being a major contributor to the forums at large.  I am of the belief that plugins carry an extra burden of support due to their nature and will endeavor to fix any problems with them ASAP.  Occasionally sarcastic and always a twisted sense of humour.",
-        "icon": "https://github.com/Squidly271/community.applications/raw/master/webImages/1645994257.png",
-        "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7M7CBCVU732XG",
-        "DonateText": "Buy me a beer",
-        "Photo": "https://raw.githubusercontent.com/Squidly271/community.applications/master/webImages/20191221_193714.jpg",
-        "Video": "https://www.youtube.com/watch?v=WMxGVfk09lU",
-        "title": "Squid's Repository",
-        "index": 252
-    },
-    {
-        "url": "https://github.com/simonsickle/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/152551-ssickle/",
-        "bio": "Creating software that makes day to day life easier. Android engineer by trade.",
-        "icon": "https://avatars.githubusercontent.com/u/51972200",
-        "DonateLink": "https://cash.app/$ssickle",
-        "DonateText": "Buy me a beer / pizza",
-        "Forum": "https://github.com/simonsickle/unraid-templates/discussions/categories/q-a-support",
-        "Twitter": "https://twitter.com/ssickle42",
-        "Discord": "https://discord.gg/TnwYRPKg72",
-        "WebPage": "https://simonsickle.com/",
-        "title": "ssickle's Repository",
-        "index": 253
-    },
-    {
-        "url": "https://github.com/Staros-Labs/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294271-starosdev/",
-        "bio": "Unraid Community Applications templates for Scrutiny - Hard Drive S.M.A.R.T Monitoring.",
-        "icon": "https://raw.githubusercontent.com/Starosdev/scrutiny/master/webapp/frontend/src/assets/images/logo/scrutiny-logo-dark.png",
-        "title": "Starosdev's Repository",
-        "index": 254
-    },
-    {
-        "url": "https://github.com/StevenDTX/unraid-plugin-repository",
-        "profile": "https://forums.unraid.net/profile/778-stevend/",
-        "bio": "Been using Unraid since 2008. Running virtualized Unraid since about 2013.",
-        "icon": "https://raw.githubusercontent.com/StevenDTX/unraid-plugin-repository/master/stevendtx.png",
-        "title": "StevenD's Repository",
-        "index": 255
-    },
-    {
-        "url": "https://github.com/superboki/UNRAID-FR",
-        "profile": "https://forums.unraid.net/profile/92630-superboki/",
-        "bio": "Hi, it's superboki! Passionate about Unraid, I'm trying with my community to create tutorials accessible in French and English.",
-        "icon": "https://avatars.githubusercontent.com/u/105635291?s=400",
-        "DonateLink": "https://tipeee.com/superboki",
-        "DonateText": "If you want to encourage this work, please consider making a small donation on Tipeee.",
-        "Facebook": "https://www.facebook.com/superboki.yt",
-        "Twitter": "https://twitter.com/superboki",
-        "Discord": "https://discord.gg/CrK5eteSjK",
-        "WebPage": "https://youtube.com/superboki",
-        "title": "superboki's Repository",
-        "index": 256
-    },
-    {
-        "url": "https://github.com/its-sven/docker-templates",
-        "profile": "https://forums.unraid.net/profile/146810-sven-w%C3%BCrth/",
-        "bio": "\ud83d\udc68\u200d\ud83d\udcbbWana be IT-Guy\n     \ud83c\udfb6Musican\n     \ud83c\udf34Living in Saarland",
-        "icon": "https://raw.githubusercontent.com/its-sven/docker-templates/main/images/sven.jpg",
-        "DonateLink": "https://paypal.me/wuerthsven",
-        "DonateText": "One Coffee or for me \ud83e\udd7a\ud83d\udc49\ud83d\udc48",
-        "Discord": "https://discord.com/invite/2KRSV2arDN",
-        "WebPage": "https://svenw.de",
-        "title": "Sven W\u00fcrth's Repository",
-        "index": 257
-    },
-    {
-        "url": "https://github.com/swiss01/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/96834-swiss01/",
-        "bio": "Hobby developer. I hope you like my work",
-        "icon": "https://raw.githubusercontent.com/swiss01/unraid-templates/refs/heads/main/swiss01/images/Esel.png",
-        "DonateLink": "https://ko-fi.com/swiss01",
-        "DonateText": "If you like my work, you are welcome to donate something, but it is voluntary ;)",
-        "title": "swiss01's Repository",
-        "index": 258
-    },
-    {
-        "url": "https://github.com/sydlexius/unraid-templates",
-        "profile": null,
-        "bio": "Unraid Docker templates maintained by sydlexius. Support for each application is available via its GitHub Issues page.",
-        "icon": "https://raw.githubusercontent.com/sydlexius/unraid-templates/main/icon.svg",
-        "WebPage": "https://github.com/sydlexius",
-        "title": "sydlexius' Repository",
-        "index": 259
-    },
-    {
-        "url": "https://github.com/warwickschroeder/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/103842-syknight/",
-        "bio": "Long time user of Unraid. Software Engineer and Solution Architect by profession.",
-        "icon": "https://avatars.githubusercontent.com/u/7676501?v=4",
-        "title": "Syknight's Repository",
-        "index": 260
-    },
-    {
-        "url": "https://github.com/jason-bean/docker-templates",
-        "profile": "https://forums.unraid.net/profile/71020-taddeusz/",
-        "bio": "I create Docker containers that are of interest to me that I hope others find also find useful.",
-        "icon": "https://raw.githubusercontent.com/jason-bean/docker-templates/master/jasonbean-repo/me.jpeg",
-        "DonateLink": "https://paypal.me/jasonsbean/0usd",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Taddeusz' Repository",
-        "index": 261
-    },
-    {
-        "url": "https://github.com/Teknicallity/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/170368-teknicallity/",
-        "bio": "Amatuer Unraid enthusiast",
-        "icon": "https://raw.githubusercontent.com/Teknicallity/unraid-templates/main/images/pope-freeman.png",
-        "Reddit": "https://www.reddit.com/user/Teknicallity",
-        "WebPage": "https://github.com/Teknicallity",
-        "title": "Teknicallity's Repository",
-        "index": 262
-    },
-    {
-        "url": "https://github.com/terratrax/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/230036-terratrax/",
-        "bio": "General technologist and self-hoster.",
-        "icon": "https://s3.ultimus.cloud/ultimus-static/terratrax/terratrax.png",
-        "DonateLink": "https://www.paypal.me/terratrax",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "terratrax's Repository",
-        "index": 263
-    },
-    {
-        "url": "https://github.com/lando786/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/270787-thatguyorlando/",
-        "bio": "Developer, father, hobbyist.",
-        "icon": "https://avatars.githubusercontent.com/u/568133?v=4&size=64",
-        "DonateLink": "https://www.buymeacoffee.com/lando786",
-        "DonateText": "If you like my work please consider buying me a coffee.",
-        "WebPage": "https://luisdasta.com/",
-        "title": "ThatGuyOrlando's Repository",
-        "index": 264
-    },
-    {
-        "url": "https://github.com/brianmiller/docker-templates",
-        "profile": "https://forums.unraid.net/profile/86892-thebrian",
-        "bio": "Just a guy.",
-        "icon": "https://forums.unraid.net/uploads/monthly_2020_06/0.jpeg.8161bb3ec6c5a310f39f444ac280ce23.jpeg",
-        "title": "TheBrian's Repository",
-        "index": 265
-    },
-    {
-        "url": "https://github.com/thecode/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/109528-thecode/",
-        "bio": "I like to contribute to projects that I use in order to make them better",
-        "icon": "https://raw.githubusercontent.com/thecode/unraid-docker-templates/main/icons/thecode.jpg",
-        "DonateLink": "https://paypal.me/levyshay",
-        "DonateText": "If you like my work please consider Donating.",
-        "Facebook": "https://www.facebook.com/levyshay/",
-        "Twitter": "https://twitter.com/intent/follow?screen_name=le1vyshay",
-        "Discord": "https://discordapp.com/users/713107876390109225/",
-        "WebPage": "https://github.com/thecode",
-        "title": "thecode's Repository",
-        "index": 266
-    },
-    {
-        "url": "https://github.com/theweebcoders/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/146571-tim000x3/",
-        "bio": "We are weebs who code. Everything we make here is free.",
-        "icon": "https://avatars.githubusercontent.com/u/172365950?s=400&u=7a2a1b390dff7240cfc5a662414c90d19eef7217&v=4",
-        "DonateLink": "https://www.buymeacoffee.com/tim000x3",
-        "DonateText": "If you like our work please consider Donating.",
-        "Discord": "https://discord.gg/S7NcUdhKRD",
-        "title": "tim000x3's Repository",
-        "index": 267
-    },
-    {
-        "url": "https://github.com/tipdec-siblyn/Urbit-on-Unraid",
-        "profile": "https://forums.unraid.net/profile/158043-tipdec-siblyn/",
-        "bio": "Hi, I create template for self-host app I love. New app and video guide soon ;) You can reach me on urbit: ~tipdec-siblyn",
-        "icon": "https://raw.githubusercontent.com/tipdec-siblyn/unraid-template/main/avatar.jpg",
-        "DonateLink": "https://github.com/tipdec-siblyn/unraid-template/blob/main/DONATION.md",
-        "DonateText": "If you like my work please consider Donating. (BTC only)",
-        "title": "tipdec-sbilyn's Repository",
-        "index": 268
-    },
-    {
-        "url": "https://github.com/titandrive/yarnl-unraid",
-        "profile": "https://forums.unraid.net/profile/294252-titandrive/",
-        "bio": "Developer of Yarnl, a self-hosted crochet pattern manager. Aficionado of crocheting and self-hosting. Source code is available on GitHub at github.com/titandrive/yarnl.",
-        "icon": "https://raw.githubusercontent.com/titandrive/yarnl-unraid/main/icon.png",
-        "DonateLink": "https://ko-fi.com/titandrive",
-        "DonateText": "If you enjoy my work please consider supporting me on Ko-fi.",
-        "Forum": "https://forums.unraid.net/topic/197409-support-titandriveyarnl/",
-        "WebPage": "https://yarnl.com",
-        "title": "titandrive's Repository",
-        "index": 269
-    },
-    {
-        "url": "https://github.com/tmchow/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/69431-tmchow/",
-        "bio": "Creating Docker containers for fun.",
-        "icon": "https://raw.githubusercontent.com/tmchow/unraid-docker-templates/master/img/avatar.jpg",
-        "title": "tmchow's Repository",
-        "index": 270
-    },
-    {
-        "url": "https://github.com/tquizzle/Docker-xml",
-        "profile": "https://forums.unraid.net/profile/13228-tq/",
-        "bio": "Just a guy who loves containers and Unraid!",
-        "icon": "https://raw.githubusercontent.com/tquizzle/Docker-xml/refs/heads/master/img/412380.png",
-        "DonateLink": "https://ko-fi.com/tquinnelly",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://github.com/tquizzle",
-        "title": "TQ's Repository",
-        "index": 271
-    },
-    {
-        "url": "https://github.com/transmute-app/unraid-template",
-        "profile": "https://forums.unraid.net/profile/294904-chase-roohms/",
-        "bio": "Transmute is a free, open source, self-hosted file converter built for privacy and automation. Convert images, video, audio, documents, spreadsheets, subtitles, and fonts entirely locally, with no file size limits and no third-party access to your files. For support, visit the GitHub Issues page.",
-        "icon": "https://raw.githubusercontent.com/transmute-app/transmute/refs/heads/main/assets/brand/beaker-red-bg.png",
-        "WebPage": "https://transmute.sh",
-        "title": "Transmute's Repository",
-        "index": 272
-    },
-    {
-        "url": "https://github.com/tubearchivist/unraid-templates",
-        "profile": null,
-        "bio": "Your selfhosted YouTube media server!",
-        "icon": "https://raw.githubusercontent.com/tubearchivist/unraid-templates/main/TubeArchivist_Logo.png",
-        "DonateLink": "https://github.com/tubearchivist/tubearchivist#donate",
-        "DonateText": "If you find this project useful, please consider Donating.",
-        "Discord": "https://www.tubearchivist.com/discord",
-        "WebPage": "https://www.tubearchivist.com/",
-        "title": "TubeArchivist's Official Repository",
-        "index": 273
-    },
-    {
-        "url": "https://github.com/Unknowncall/adsb-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/206238-unknowncall/",
-        "bio": "Creating docker templates for Unraid! Please let me know if you want additional templates.",
-        "icon": "https://avatars.githubusercontent.com/u/8108400?v=4",
-        "title": "Unknowncall's Repository",
-        "index": 274
-    },
-    {
-        "url": "https://github.com/Reaparr/Unraid-CA-Templates",
-        "profile": "https://forums.unraid.net/profile/102645-unmax/",
-        "bio": "Currently working hard on developing Reaparr! Let me know if you have any ideas or feedback on how to make it even more awesome!",
-        "icon": "https://avatars.githubusercontent.com/u/15127381",
-        "DonateLink": "https://github.com/sponsors/JasonLandbridge",
-        "DonateText": "Consider throwing money at me to get all your wishes granted!",
-        "WebPage": "https://github.com/JasonLandbridge",
-        "title": "Unmax's Repository",
-        "index": 275
-    },
-    {
-        "url": "https://github.com/UNRA1DUser/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/120631-unra1duser/",
-        "bio": "I am trying to create Docker containers with official images. I create the template as modular as possible so that almost all settings can be set.",
-        "icon": "https://raw.githubusercontent.com/UNRA1DUser/unraid-docker-templates/main/templates/img/avatar.png",
-        "DonateLink": "https://www.paypal.com/paypalme/M4rc31",
-        "DonateText": "If you like my work and would like to support me please consider Donating.",
-        "WebPage": "https://github.com/UNRA1DUser/unraid-docker-templates",
-        "title": "UNRA1DUser's Repository",
-        "index": 276
-    },
-    {
-        "url": "https://github.com/VandaLpr/unRAID-CA-templates",
-        "profile": null,
-        "bio": "A bunch of happy folks adding what the community want, to give them choice, for free. Request stuff on our github https://github.com/selfhosters/Unraid-CA-templates",
-        "icon": "https://github.com/selfhosters.png",
-        "Forum": "https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/",
-        "Discord": "https://discord.gg/qWPbc8R",
-        "WebPage": "https://selfhosters.net/",
-        "title": "VandaL Repository",
-        "index": 277
-    },
-    {
-        "url": "https://github.com/vinid223/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/91081-vinid223",
-        "bio": "Creating Docker containers for my needs and sharing them with the community.",
-        "icon": "https://raw.githubusercontent.com/vinid223/unraid-docker-templates/master/vinid223/images/avatar.png",
-        "DonateLink": "https://paypal.me/vinid223",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "vinid223's Repository",
-        "index": 278
-    },
-    {
-        "url": "https://github.com/VladoPortos/vladoportos-unraid-xml",
-        "profile": "https://forums.unraid.net/profile/103082-vladoportos/",
-        "bio": "Trying my best to maintain Folder.View2 and SkillGoblin.",
-        "icon": "https://raw.githubusercontent.com/VladoPortos/vladoportos-unraid-xml/master/img/avatar.png",
-        "DonateLink": "https://ko-fi.com/vladoportos",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://skillgoblin.com",
-        "title": "VladoPortos' Repository",
-        "index": 279
-    },
-    {
-        "url": "https://github.com/vrx-666/unraid-xml",
-        "profile": "https://forums.unraid.net/profile/128590-vrx/",
-        "bio": "Creating Docker containers for fun. Most often for my own needs, which are not met by other available in CA.",
-        "icon": "https://raw.githubusercontent.com/vrx-666/unraid-xml/master/img/mask.jpg",
-        "title": "vrx's Repository",
-        "index": 280
-    },
-    {
-        "url": "https://github.com/TorBox-App/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/247536-wamy/",
-        "bio": "Official TorBox CA Profile for TorBox Docker Apps on Unraid!",
-        "icon": "https://torbox.app/logo.png",
-        "DonateLink": "https://torbox.app/subscription",
-        "DonateText": "To use these images to their full capacity, get a paid TorBox account here.",
-        "Reddit": "https://join-reddit.torbox.app",
-        "Twitter": "https://x.com/torbox_app",
-        "Discord": "https://join-discord.torbox.app",
-        "WebPage": "https://torbox.app",
-        "title": "Wamy's Repository",
-        "index": 281
-    },
-    {
-        "url": "https://github.com/Waseh/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/5193-waseh/",
-        "bio": "Maintaining a plugin which installs rclone on your Unraid machine.",
-        "icon": "https://raw.githubusercontent.com/Waseh/unraidtemplates/master/WasehLogo.png",
-        "DonateLink": "https://paypal.me/WasehDev",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Waseh's Repository",
-        "index": 282
-    },
-    {
-        "url": "https://github.com/itsnotwebby/unraid-templates",
-        "profile": null,
-        "bio": "Kind of a big deal. <3 Unraid",
-        "icon": "https://raw.githubusercontent.com/itsnotwebby/unraid-templates/main/webby.png",
-        "WebPage": "https://github.com/itsnotwebby",
-        "title": "Webby's Repository",
-        "index": 283
-    },
-    {
-        "url": "https://github.com/W3LFARe/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/129748-welfare/",
-        "bio": "Just Making templates and containers for things I find interesting. <3 Unraid",
-        "icon": "https://raw.githubusercontent.com/W3LFARe/unraid_templates/main/WELFARE.png",
-        "DonateLink": "https://ko-fi.com/w3lfare",
-        "DonateText": "",
-        "WebPage": "https://github.com/W3LFARe",
-        "title": "welfare's Repository",
-        "index": 284
-    },
-    {
-        "url": "https://github.com/Womabre/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/90075-womabre",
-        "bio": "Creator and maintainer of the iCloudPD Docker template.",
-        "icon": "https://raw.githubusercontent.com/Womabre/unraid-docker-templates/master/images/132746.jpg",
-        "DonateLink": "https://paypal.me/wmbreedveld",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Womabre's Repository",
-        "index": 285
-    },
-    {
-        "url": "https://github.com/wupasscat/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103746-wupasscat/",
-        "bio": "https://github.com/wupasscat/Unraid-templates",
-        "icon": "https://raw.githubusercontent.com/wupasscat/wupasscat/main/profile.png",
-        "DonateLink": "https://www.buymeacoffee.com/wupasscat",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "wupasscat's Repository",
-        "index": 286
-    },
-    {
-        "url": "https://github.com/xthursdayx/docker-templates",
-        "profile": "https://forums.unraid.net/profile/69067-zandrsn/",
-        "bio": "I maintain a number of Docker images based on Debian, Ubuntu and Alpine Linux, with the goal of producing simple, stable and user-friendly containers. I also create templates for Unraid users.",
-        "icon": "https://raw.githubusercontent.com/xthursdayx/docker-templates/master/xthursdayx/images/xthursdayx.png",
-        "DonateLink": "https://www.buymeacoffee.com/xthursdayx",
-        "DonateText": "If you appreciate my work please consider buying me a coffee, cheers!",
-        "Forum": "https://forums.unraid.net/topic/88410-support-xthursdayx-unraid-docker-templates/",
-        "title": "xthursdayx's Repository",
-        "index": 287
-    },
-    {
-        "url": "https://github.com/xWeegix/templates",
-        "profile": "https://forums.unraid.net/profile/132338-xweegix/",
-        "bio": "Adding templates for cool projects. Please support the authors and contributors.",
-        "icon": "https://github.com/xWeegix.png",
-        "title": "xWeegix's Repository",
-        "index": 288
-    },
-    {
-        "url": "https://gitlab.com/yayitazale/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/88392-yayitazale/",
-        "bio": "Creating Docker templates for personal projects",
-        "icon": "https://github.com/yayitazale.png",
-        "DonateLink": "https://paypal.me/JosebaEgiaLarrinaga",
-        "DonateText": "If you like my work please consider Donating.",
-        "WebPage": "https://firstcommit.dev/",
-        "title": "yayitazale's Repository",
-        "index": 289
-    },
-    {
-        "url": "https://github.com/Yoruio/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126098-yoruio/",
-        "bio": "Mostly just templates of my containers, but stay tuned for more?",
-        "icon": "https://avatars.githubusercontent.com/u/38411921",
-        "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=R44M45FYUVUDJ",
-        "DonateText": "Help me through life with a shot or two of age-appropriate beverage!",
-        "title": "Yoruio's Repository",
-        "index": 290
-    },
-    {
-        "url": "https://github.com/Yusseiin/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279816-yusseiin/",
-        "bio": "I create Docker applications with one main goal: making life easier for the user. My containers are designed to work out of the box, stay up to date automatically, and require as little manual setup as possible\u2014so you can focus on using the app, not maintaining it.",
-        "icon": "https://raw.githubusercontent.com/yusseiin/unraid-templates/main/img/avatar.jpg",
-        "DonateLink": "https://www.paypal.com/paypalme/yusseiin",
-        "DonateText": "If you like my work please consider Donating.",
-        "title": "Yusseiin's Repository",
-        "index": 291
-    },
-    {
-        "url": "https://github.com/devzwf/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/119200-zappyzap/",
-        "bio": "Noname dude making some template to help.",
-        "icon": "https://raw.githubusercontent.com/devzwf/unraid-docker-templates/main/images/Nutz.jpg",
-        "DonateLink": "https://ko-fi.com/devzwf",
-        "DonateText": "Don't donate to me! Instead, please donate the creators of the apps, but if you insist",
-        "title": "ZappyZap's Repository",
-        "index": 292
-    },
-    {
-        "url": "https://github.com/zgorizzo69/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119851-zgo/",
-        "bio": "All about decentralization.",
-        "icon": "https://github.com/zgorizzo69.png",
-        "title": "zgo's Repository",
-        "index": 293
-    },
-    {
-        "url": "https://github.com/vertex-app/docker-template",
-        "profile": "https://forums.unraid.net/profile/171336-%E6%A0%97%E5%B1%B1%E6%9C%AA%E6%9D%A5/",
-        "bio": "Good Luck!",
-        "icon": "https://pic.lswl.in/images/2021/12/07/8362b5b3fe8744e0f3bfa93f1105857d.jpg",
-        "title": "\u6817\u5c71\u672a\u6765 Repository",
-        "index": 294
-    },
-    {
-        "url": "https://github.com/7oasty/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/189568-7oasty/",
-        "title": "7oasty's Repository",
-        "index": 295
-    },
-    {
-        "url": "https://github.com/ahmedbadr3/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294773-abadr/",
-        "title": "abadr's Repository",
-        "index": 296
-    },
-    {
-        "url": "https://github.com/drewzh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/266696-abreast-statesman5405/",
-        "title": "abreast-statesman5405's Repository",
-        "index": 297
-    },
-    {
-        "url": "https://github.com/Watso4183/Unraid",
-        "profile": "https://forums.unraid.net/profile/293586-acmepluto/",
-        "title": "AcmePluto's Repository",
-        "index": 298
-    },
-    {
-        "url": "https://github.com/aeleos/cloudflared",
-        "profile": "https://forums.unraid.net/profile/78732-aeleos/",
-        "title": "aeleos' Repository",
-        "index": 299
-    },
-    {
-        "url": "https://github.com/afairgiant/MediKeep_unraid",
-        "profile": "https://forums.unraid.net/profile/116260-afairgiant/",
-        "title": "afairgiant's Repository",
-        "index": 300
-    },
-    {
-        "url": "https://github.com/wbynum/docker-templates",
-        "profile": "https://forums.unraid.net/profile/97630-aggie1999/",
-        "title": "Aggie1999's Repository",
-        "index": 301
-    },
-    {
-        "url": "https://github.com/ajb3932/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/276974-ajb3932/",
-        "title": "ajb3932's Repository",
-        "index": 302
-    },
-    {
-        "url": "https://github.com/alexbn71/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169325-alexbn71/",
-        "title": "alexbn71's Repository",
-        "index": 303
-    },
-    {
-        "url": "https://github.com/AlexGreenUK/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/116574-alexgreenuk/",
-        "title": "AlexGreenUK's Repository",
-        "index": 304
-    },
-    {
-        "url": "https://github.com/allaboutduncan/clu-comics",
-        "profile": null,
-        "DonateLink": "https://www.buymeacoffee.com/allaboutduncan",
-        "DonateText": "Buy me a coffee",
-        "title": "AllAboutDuncan's Repository",
-        "index": 305
-    },
-    {
-        "url": "https://github.com/evilalmus/UNRAID_COMMUNITY_APPS",
-        "profile": "https://forums.unraid.net/profile/178171-almus/",
-        "title": "almus' Repository",
-        "index": 306
-    },
-    {
-        "url": "https://github.com/alyssaholland99/unraid-immich-tiktok-remover",
-        "profile": "https://forums.unraid.net/profile/289132-alyssaholland/",
-        "title": "AlyssaHolland's Repository",
-        "index": 307
-    },
-    {
-        "url": "https://github.com/anojht/invoiceninja",
-        "profile": "https://forums.unraid.net/profile/87757-microservices/",
-        "title": "anojht's Repository",
-        "index": 308
-    },
-    {
-        "url": "https://github.com/anym001/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/119296-anym001/",
-        "title": "Anym001's Repository",
-        "index": 309
-    },
-    {
-        "url": "https://github.com/AradD7/lightarr-template-files",
-        "profile": "https://forums.unraid.net/profile/293896-arad",
-        "title": "Arad's Repository",
-        "index": 310
-    },
-    {
-        "url": "https://github.com/argash/amongusdiscord_unraid",
-        "profile": "https://forums.unraid.net/profile/112259-argash/",
-        "title": "argash's Repository",
-        "index": 311
-    },
-    {
-        "url": "https://github.com/AronMarinelli/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126179-aronm/",
-        "title": "AronM's Repository",
-        "index": 312
-    },
-    {
-        "url": "https://github.com/asparon/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/96069-asparon/",
-        "title": "Asparon's Repository",
-        "index": 313
-    },
-    {
-        "url": "https://github.com/atribe/unRAID-docker",
-        "profile": "https://forums.unraid.net/profile/70671-atribe/",
-        "title": "atribe's Repository",
-        "index": 314
-    },
-    {
-        "url": "https://github.com/b42n1/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/167912-b4rny/",
-        "title": "B4rny's Repository",
-        "index": 315
-    },
-    {
-        "url": "https://github.com/BBergle/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/228849-bbergle/",
-        "title": "BBergle's Repository",
-        "index": 316
-    },
-    {
-        "url": "https://github.com/benderstwin/docker-templates",
-        "profile": "https://forums.unraid.net/profile/11326-bryanwirth/",
-        "title": "Bender's Repository",
-        "index": 317
-    },
-    {
-        "url": "https://github.com/gbendy/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/275025-bendy/",
-        "title": "bendy's Repository",
-        "index": 318
-    },
-    {
-        "url": "https://github.com/bert-mccutchen/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/178618-bert-mccutchen/",
-        "title": "Bert McCutchen's Repository",
-        "index": 319
-    },
-    {
-        "url": "https://github.com/bfox135/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/174793-bfox135/",
-        "title": "Bfox135's Repository",
-        "index": 320
-    },
-    {
-        "url": "https://github.com/bghizzy/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/268319-bg_hizzy/",
-        "title": "bg_hizzy's Repository",
-        "index": 321
-    },
-    {
-        "url": "https://github.com/BryanGoble/docker-templates",
-        "profile": "https://forums.unraid.net/profile/290235-bgubs/",
-        "title": "bgubs' Repository",
-        "index": 322
-    },
-    {
-        "url": "https://github.com/BigManDave/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/133103-bigmandave/",
-        "title": "BigManDave's Repository",
-        "index": 323
-    },
-    {
-        "url": "https://github.com/bigsing/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/7676-bigsing/",
-        "title": "bigsing's Repository",
-        "index": 324
-    },
-    {
-        "url": "https://github.com/Billyboii/mcsmanager-unraid",
-        "profile": "https://forums.unraid.net/profile/293091-billyboi/",
-        "title": "billyboi's Repository",
-        "index": 325
-    },
-    {
-        "url": "https://github.com/bitcryptic-gw/unraid-pi-network-node",
-        "profile": "https://forums.unraid.net/profile/287583-bitcryptic/",
-        "title": "BitCryptic's Repository",
-        "index": 326
-    },
-    {
-        "url": "https://github.com/BitlessByte0/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/261347-bitlessbyte/",
-        "title": "BitlessByte's Repository",
-        "index": 327
-    },
-    {
-        "url": "https://github.com/TheBlackBush/bambulab_metrics_exporter",
-        "profile": "https://forums.unraid.net/profile/119627-blackbush/",
-        "title": "BlackBush's Repository",
-        "index": 328
-    },
-    {
-        "url": "https://github.com/kclif9/Unraid_Templates",
-        "profile": "https://forums.unraid.net/profile/279194-bluelamp3445/",
-        "title": "blue.lamp3445's Repository",
-        "index": 329
-    },
-    {
-        "url": "https://github.com/bluegizmo83/DockerXMLs",
-        "profile": "https://forums.unraid.net/profile/105585-bluegizmo83",
-        "title": "bluegizmo83's Repository",
-        "index": 330
-    },
-    {
-        "url": "https://github.com/bmartino1/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/118010-bmartino1/",
-        "title": "bmartino1's Repository",
-        "index": 331
-    },
-    {
-        "url": "https://github.com/bobbintb/docker-templates",
-        "profile": "https://forums.unraid.net/profile/550-bobbintb/",
-        "title": "bobbintb's Repository",
-        "index": 332
-    },
-    {
-        "url": "https://github.com/StuffAnThings/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/76370-bobokun/",
-        "title": "bobokun's Repository",
-        "index": 333
-    },
-    {
-        "url": "https://github.com/Bobstin/willow-application-server",
-        "profile": "https://forums.unraid.net/profile/227361-bobstin/",
-        "title": "Bobstin's Repository",
-        "index": 334
-    },
-    {
-        "url": "https://github.com/bonedrums/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/72855-bonedrums/",
-        "title": "bonedrums' Repository",
-        "index": 335
-    },
-    {
-        "url": "https://github.com/olilanz/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/175858-boomshakalaka/",
-        "title": "boomshakala's Repository",
-        "index": 336
-    },
-    {
-        "url": "https://github.com/botmem/botmem",
-        "profile": null,
-        "title": "botmem",
-        "index": 337
-    },
-    {
-        "url": "https://github.com/Bovive/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/259292-bovive/",
-        "title": "Bovive's Repository",
-        "index": 338
-    },
-    {
-        "url": "https://github.com/breadlysm/Breads-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/84220-breadlysm/",
-        "title": "breadlysm's Repository",
-        "index": 339
-    },
-    {
-        "url": "https://github.com/brettm357/docker-templates",
-        "profile": "https://forums.unraid.net/profile/62222-brettm357/",
-        "title": "brettm357's Repository",
-        "index": 340
-    },
-    {
-        "url": "https://github.com/brq-ae/boltarr-templates",
-        "profile": null,
-        "title": "Brq.ae Repository",
-        "index": 341
-    },
-    {
-        "url": "https://github.com/brycelarge/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/112270-brycelarge/",
-        "title": "brycelarge's Repository",
-        "index": 342
-    },
-    {
-        "url": "https://github.com/bubba925/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/189614-bubbadrk/",
-        "title": "bubba925's Repository",
-        "index": 343
-    },
-    {
-        "url": "https://github.com/emaspa/emaspa-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/71014-bubbl3/",
-        "title": "bubbl3's Repository",
-        "index": 344
-    },
-    {
-        "url": "https://github.com/FrankM77/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/153626-built2succeed/",
-        "title": "Built2Succeed's Repository",
-        "index": 345
-    },
-    {
-        "url": "https://github.com/jshridha/templates",
-        "profile": "https://forums.unraid.net/profile/7061-bungy/",
-        "title": "Bungy's Repository",
-        "index": 346
-    },
-    {
-        "url": "https://github.com/buxxdev/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/291279-mbxy/",
-        "title": "buxxdev's Repository",
-        "index": 347
-    },
-    {
-        "url": "https://github.com/Belstrekkie/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/224258-bversluis/",
-        "title": "BVersluis' Repository",
-        "index": 348
-    },
-    {
-        "url": "https://github.com/C3004/Unraid-Templates-C3004",
-        "profile": "https://forums.unraid.net/profile/142775-c3004/",
-        "title": "C3004's Repository",
-        "index": 349
-    },
-    {
-        "url": "https://github.com/C4ArtZ/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/106324-c4artz/",
-        "title": "c4artz' Repository",
-        "index": 350
-    },
-    {
-        "url": "https://github.com/cabi24/notenregal",
-        "profile": null,
-        "title": "cabi24's Repository",
-        "index": 351
-    },
-    {
-        "url": "https://github.com/cajuncoding/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/134398-cajuncoding/",
-        "title": "CajunCoding's Repository",
-        "index": 352
-    },
-    {
-        "url": "https://github.com/Camc314/unraid-jellyfin-vue",
-        "profile": "https://forums.unraid.net/profile/123309-camc314/",
-        "title": "Camc314's Repository",
-        "index": 353
-    },
-    {
-        "url": "https://github.com/cameron581/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/253440-cameron581/",
-        "title": "Cameron581's Repository",
-        "index": 354
-    },
-    {
-        "url": "https://github.com/TheMapledCog/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/168586-campu0999/",
-        "title": "campu0999's Repository",
-        "index": 355
-    },
-    {
-        "url": "https://github.com/P3R-CO/unraid",
-        "profile": "https://forums.unraid.net/profile/106374-captasic/",
-        "title": "capt.asic's Repository",
-        "index": 356
-    },
-    {
-        "url": "https://github.com/CaptainPimpJr/Unraid-Community-Applications",
-        "profile": "https://forums.unraid.net/profile/271177-cptpimpjunior/",
-        "title": "CaptainPimpJr's Repository",
-        "index": 357
-    },
-    {
-        "url": "https://github.com/carrotwaxr/peek-stash-browser",
-        "profile": "https://forums.unraid.net/profile/291876-carrot-waxxr/",
-        "title": "Carrot Waxxr's Repository",
-        "index": 358
-    },
-    {
-        "url": "https://github.com/chacawaca/post-recording-xml",
-        "profile": "https://forums.unraid.net/profile/111526-chacawaca",
-        "title": "Chacawaca's Repository",
-        "index": 359
-    },
-    {
-        "url": "https://github.com/PotentialIngenuity/petio-unraid",
-        "profile": "https://forums.unraid.net/profile/107700-chargingcosmonaut/",
-        "title": "ChargingCosmonaut's Repository",
-        "index": 360
-    },
-    {
-        "url": "https://github.com/Maximize1107/unRAID-Templates",
-        "profile": "https://forums.unraid.net/profile/136631-chrislb/",
-        "title": "chrislb's Repository",
-        "index": 361
-    },
-    {
-        "url": "https://github.com/ciegg/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/155366-cieg/",
-        "title": "cieg's Repository",
-        "index": 362
-    },
-    {
-        "url": "https://github.com/ckocyigit/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/110566-ck98/",
-        "title": "CK98's Repository",
-        "index": 363
-    },
-    {
-        "url": "https://github.com/clowrym/docker-templates",
-        "profile": "https://forums.unraid.net/profile/26570-clowrym/",
-        "title": "clowrym's Repository",
-        "index": 364
-    },
-    {
-        "url": "https://github.com/Adidasdaniel98/RepetierDocker",
-        "profile": "https://forums.unraid.net/profile/120747-codeluxe/",
-        "title": "Codeluxe's Repository",
-        "index": 365
-    },
-    {
-        "url": "https://github.com/coppit/docker-templates",
-        "profile": "https://forums.unraid.net/profile/167-coppit/",
-        "title": "coppit's Repository",
-        "index": 366
-    },
-    {
-        "url": "https://github.com/CordlessWool/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/289062-cordlesswool/",
-        "title": "CordlessWool's Repository",
-        "index": 367
-    },
-    {
-        "url": "https://github.com/criscrafter/Unraid-CA",
-        "profile": "https://forums.unraid.net/profile/154961-criscrafter/",
-        "title": "criscrafter's Repository",
-        "index": 368
-    },
-    {
-        "url": "https://github.com/pairofcrocs/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/98010-crocs/",
-        "title": "Croc's Repository",
-        "index": 369
-    },
-    {
-        "url": "https://github.com/NickM-27/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/128178-crzynik/",
-        "title": "crzynik's Repository",
-        "index": 370
-    },
-    {
-        "url": "https://github.com/cschanot/docker-templates",
-        "profile": "https://forums.unraid.net/profile/80091-cschanot/",
-        "title": "cschanot's Repository",
-        "index": 371
-    },
-    {
-        "url": "https://github.com/glauth/unraid-glauth",
-        "profile": "https://forums.unraid.net/profile/111590-cyansmoker/",
-        "title": "cyansmoker's Repository",
-        "index": 372
-    },
-    {
-        "url": "https://github.com/CyaOnDaNet/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/100638-cyaondanet/",
-        "title": "CyaOnDaNet's Repository",
-        "index": 373
-    },
-    {
-        "url": "https://github.com/D34DC3N73R/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/101684-d34dc3n73r/",
-        "title": "D34DC3N73R's Repository",
-        "index": 374
-    },
-    {
-        "url": "https://github.com/d8ahazard/unraid-repository",
-        "profile": null,
-        "title": "d8ahazard's Repository",
-        "index": 375
-    },
-    {
-        "url": "https://github.com/d8sychain/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/72950-d8sychain/",
-        "title": "d8sychain's Repository",
-        "index": 376
-    },
-    {
-        "url": "https://github.com/knilix/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126551-da-do-ron/",
-        "title": "da do ron's Repository",
-        "index": 377
-    },
-    {
-        "url": "https://github.com/daman20/ca-xmls",
-        "profile": "https://forums.unraid.net/profile/122785-daman12/",
-        "title": "daman12's Repository",
-        "index": 378
-    },
-    {
-        "url": "https://github.com/damongolding/immich-kiosk-unraid",
-        "profile": "https://forums.unraid.net/profile/285555-damongolding/",
-        "title": "DamonGolding's Repository",
-        "index": 379
-    },
-    {
-        "url": "https://github.com/DanRegalia/UNRAID",
-        "profile": "https://forums.unraid.net/profile/103107-danregalia/",
-        "title": "DanRegalia's Repository",
-        "index": 380
-    },
-    {
-        "url": "https://github.com/daredoes/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/157186-daredoes/",
-        "title": "daredoes' Repository",
-        "index": 381
-    },
-    {
-        "url": "https://github.com/jcesclapez/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/280038-darklesc/",
-        "title": "Darklesc's Repository",
-        "index": 382
-    },
-    {
-        "url": "https://github.com/Darkside138/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/166210-darkside138/",
-        "title": "Darkside138's Repository",
-        "index": 383
-    },
-    {
-        "url": "https://github.com/DavidSpek/homelablabelmaker",
-        "profile": "https://forums.unraid.net/profile/96461-davidspek/",
-        "title": "DavidSpek's 2nd Repository",
-        "index": 384
-    },
-    {
-        "url": "https://github.com/DavidSpek/unraid_docker_templates",
-        "profile": "https://forums.unraid.net/profile/96461-davidspek",
-        "title": "DavidSpek's Repository",
-        "index": 385
-    },
-    {
-        "url": "https://github.com/fdm-monster/fdm-monster-unraid",
-        "profile": "https://forums.unraid.net/profile/124887-davidzwa/",
-        "title": "davidzwa's Repository",
-        "index": 386
-    },
-    {
-        "url": "https://github.com/freeskier93/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125013-dcooper/",
-        "title": "dcooper's Repository",
-        "index": 387
-    },
-    {
-        "url": "https://github.com/eulaly/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/99159-dealbakerjones/",
-        "title": "dealbakerjones' Repository",
-        "index": 388
-    },
-    {
-        "url": "https://github.com/DearTanker/Unraid-Docker-Template",
-        "profile": "https://forums.unraid.net/profile/98483-deartanker/",
-        "title": "DearTanker's Repository",
-        "index": 389
-    },
-    {
-        "url": "https://github.com/kurrier-org/kurrier",
-        "profile": "https://forums.unraid.net/profile/292187-debuggy12/",
-        "title": "debuggy12's Repository",
-        "index": 390
-    },
-    {
-        "url": "https://github.com/dereckhall/unraid-plugin-templates",
-        "profile": "https://forums.unraid.net/profile/294777-dereck/",
-        "title": "Dereck's Repository",
-        "index": 391
-    },
-    {
-        "url": "https://github.com/dervish666/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/179627-dervish/",
-        "title": "dervish's Repository",
-        "index": 392
-    },
-    {
-        "url": "https://github.com/DevlinDelFuego/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287879-devlindelfuego/",
-        "title": "DevlinDelFuego's Repository",
-        "index": 393
-    },
-    {
-        "url": "https://github.com/chirmstream/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103420-dglb99/",
-        "title": "dglb99's Repository",
-        "index": 394
-    },
-    {
-        "url": "https://github.com/dgongut/UnRAID-Templates",
-        "profile": "https://forums.unraid.net/profile/250140-dgongut/",
-        "title": "dgongut's Repository",
-        "index": 395
-    },
-    {
-        "url": "https://github.com/dhruvinsh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/146712-dhruvin/",
-        "title": "Dhruvin's Repository",
-        "index": 396
-    },
-    {
-        "url": "https://github.com/quimnut/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/15731-dibbz/",
-        "title": "dibbz' Repository",
-        "index": 397
-    },
-    {
-        "url": "https://github.com/Dimtar/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/7694-dimtar/",
-        "title": "dimtar's Repository",
-        "index": 398
-    },
-    {
-        "url": "https://github.com/wandercone/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/116223-discoverit/",
-        "title": "DiscoverIT's Repository",
-        "index": 399
-    },
-    {
-        "url": "https://github.com/piranha771/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/159409-divid/",
-        "title": "Divid's Repository",
-        "index": 400
-    },
-    {
-        "url": "https://github.com/dixtdf/templates",
-        "profile": "https://forums.unraid.net/profile/262846-dixtdf/",
-        "title": "dixtdf's Repository",
-        "index": 401
-    },
-    {
-        "url": "https://github.com/DJ3vil/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/178613-dj3vil/",
-        "title": "DJ3vil's Repository",
-        "index": 402
-    },
-    {
-        "url": "https://github.com/dmacias72/unRAID-CA",
-        "profile": "https://forums.unraid.net/profile/11874-dmacias/",
-        "title": "dmacias' Repository",
-        "index": 403
-    },
-    {
-        "url": "https://github.com/docgyver/unraid-v6-plugins",
-        "profile": "https://forums.unraid.net/profile/21303-docgyver/",
-        "title": "docgyver's Repository",
-        "index": 404
-    },
-    {
-        "url": "https://github.com/doron1/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/8006-doron/",
-        "title": "doron's Repository",
-        "index": 405
-    },
-    {
-        "url": "https://github.com/ltdstudio/MoviePilot_unraid_CA",
-        "profile": "https://forums.unraid.net/profile/284198-doudou1234/",
-        "title": "doudou1234's Repository",
-        "index": 406
-    },
-    {
-        "url": "https://github.com/Drazzilb08/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/63966-drazzilb/",
-        "title": "Drazzilb's Repository",
-        "index": 407
-    },
-    {
-        "url": "https://github.com/davemachado/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/291782-drm8/",
-        "title": "drm's Repository",
-        "index": 408
-    },
-    {
-        "url": "https://github.com/drohack/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/275784-drohack/",
-        "title": "drohack's Repository",
-        "index": 409
-    },
-    {
-        "url": "https://github.com/Droppisalt/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/229261-droppisalt/",
-        "title": "Droppisalt's Repository",
-        "index": 410
-    },
-    {
-        "url": "https://github.com/Polemus/Unraid",
-        "profile": "https://forums.unraid.net/profile/140455-dusty-roberts/",
-        "title": "Dusty Roberts' Repository",
-        "index": 411
-    },
-    {
-        "url": "https://github.com/lomorage/unraid-template",
-        "profile": "https://forums.unraid.net/profile/138957-dwebf/",
-        "title": "DwebF's Repository",
-        "index": 412
-    },
-    {
-        "url": "https://github.com/unraid/dynamix-plugins-xml",
-        "profile": "https://forums.unraid.net/profile/2736-bonienl/",
-        "title": "Dynamix Plugin Repository",
-        "index": 413
-    },
-    {
-        "url": "https://github.com/DyonR/docker-templates",
-        "profile": "https://forums.unraid.net/profile/79298-dyon/",
-        "title": "Dyon's Repository",
-        "index": 414
-    },
-    {
-        "url": "https://github.com/ItsEcholot/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/134301-echolot/",
-        "title": "Echolot's Repository",
-        "index": 415
-    },
-    {
-        "url": "https://github.com/EddCase/unRAID_Templates",
-        "profile": "https://forums.unraid.net/profile/10833-eddcase/",
-        "title": "EddCase's Repository",
-        "index": 416
-    },
-    {
-        "url": "https://github.com/egnerdata/unraid-docker-template-papra",
-        "profile": "https://forums.unraid.net/profile/274607-egnerdata/",
-        "title": "Egnerdata's Repository",
-        "index": 417
-    },
-    {
-        "url": "https://github.com/EideardVMR/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/204759-eideard/",
-        "title": "Eideard's Repository",
-        "index": 418
-    },
-    {
-        "url": "https://github.com/Eksistenze/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/153955-eksistenze/",
-        "title": "Eksistenze's Repository",
-        "index": 419
-    },
-    {
-        "url": "https://github.com/edgar971/open-chat",
-        "profile": "https://forums.unraid.net/profile/238357-el_pino/",
-        "title": "el_pino's Repository",
-        "index": 420
-    },
-    {
-        "url": "https://github.com/ElectricBrainUK/docker-templates",
-        "profile": "https://forums.unraid.net/profile/98185-electricbrainuk",
-        "title": "ElectricBrainUK's Repository",
-        "index": 421
-    },
-    {
-        "url": "https://github.com/anibridge/anibridge-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294357-eliasbenb/",
-        "title": "eliasbenb's Repository",
-        "index": 422
-    },
-    {
-        "url": "https://github.com/elzik/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/201488-elzik/",
-        "title": "elzik's Repository",
-        "index": 423
-    },
-    {
-        "url": "https://github.com/MediaBrowser/Emby.Build",
-        "profile": null,
-        "title": "Emby Repository",
-        "index": 424
-    },
-    {
-        "url": "https://github.com/rschuiling/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/261141-emphyrio/",
-        "title": "Emphyrio's Repository",
-        "index": 425
-    },
-    {
-        "url": "https://github.com/emptyfish/unraid-apps",
-        "profile": "https://forums.unraid.net/profile/112283-emptyfish/",
-        "title": "emptyfish's Repository",
-        "index": 426
-    },
-    {
-        "url": "https://github.com/Entree3k/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/201585-entree3000/",
-        "title": "entree3000's Repository",
-        "index": 427
-    },
-    {
-        "url": "https://github.com/twist3dimages/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/137900-exes/",
-        "title": "Exes' Repository",
-        "index": 428
-    },
-    {
-        "url": "https://github.com/peterthepeter/groly",
-        "profile": null,
-        "title": "facro's Repository",
-        "index": 429
-    },
-    {
-        "url": "https://github.com/stefan-matic/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/269247-fallen94/",
-        "title": "Fallen94's Repository",
-        "index": 430
-    },
-    {
-        "url": "https://github.com/andrejwithj/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/168139-fancyshmancy/",
-        "title": "fancyshmancy's Repository",
-        "index": 431
-    },
-    {
-        "url": "https://github.com/fanningert/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/77170-fanningert/",
-        "title": "fanningert's Repository",
-        "index": 432
-    },
-    {
-        "url": "https://github.com/fccview/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/293085-fccview/",
-        "title": "fccview's Repository",
-        "index": 433
-    },
-    {
-        "url": "https://github.com/fejich/unRAID-plugins-templates",
-        "profile": "https://forums.unraid.net/profile/122412-fejich/",
-        "title": "fejich's Repository",
-        "index": 434
-    },
-    {
-        "url": "https://github.com/fiR3W4LL87/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/113873-fir3w4ll/",
-        "title": "fiR3W4LL's Repository",
-        "index": 435
-    },
-    {
-        "url": "https://github.com/fisherd80/Listarr",
-        "profile": null,
-        "title": "fisherd91's Repository",
-        "index": 436
-    },
-    {
-        "url": "https://github.com/fizzyfrys/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119591-fizzyfrys/",
-        "title": "fizzyfrys' Repository",
-        "index": 437
-    },
-    {
-        "url": "https://github.com/Flight777/unraid_justworks_templates",
-        "profile": "https://forums.unraid.net/profile/119250-flight777",
-        "title": "Flight777's Repository",
-        "index": 438
-    },
-    {
-        "url": "https://github.com/CyanLabs/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/72406-fma965/",
-        "title": "Fma965's Repository",
-        "index": 439
-    },
-    {
-        "url": "https://github.com/johnngone/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/258273-forder/",
-        "title": "Forder's Repository",
-        "index": 440
-    },
-    {
-        "url": "https://github.com/EdwardChamberlain/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/122583-forum-layman/",
-        "title": "Forum-Layman's Repository",
-        "index": 441
-    },
-    {
-        "url": "https://github.com/fosrl/templates",
-        "profile": "https://forums.unraid.net/profile/96141-milo-schwartz/",
-        "title": "Fossorial's Repository",
-        "index": 442
-    },
-    {
-        "url": "https://github.com/FoxxMD/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/85599-foxxmd/",
-        "title": "FoxxMD's Repository",
-        "index": 443
-    },
-    {
-        "url": "https://github.com/frakman1/docker-templates",
-        "profile": "https://forums.unraid.net/profile/96005-frakman1",
-        "title": "frakman1's Repository",
-        "index": 444
-    },
-    {
-        "url": "https://github.com/FreakErn/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/129382-freakern/",
-        "title": "FreakErn's Repository",
-        "index": 445
-    },
-    {
-        "url": "https://gitlab.com/crafty-controller/crafty-4",
-        "profile": "https://forums.unraid.net/profile/126877-freddy0/",
-        "title": "freddy0's Repository",
-        "index": 446
-    },
-    {
-        "url": "https://github.com/friendlyFriend4000/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/244776-friendlyfriend/",
-        "title": "FriendlyFriend's Repository",
-        "index": 447
-    },
-    {
-        "url": "https://github.com/FunkeCoder23/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/273394-funkecoder23/",
-        "title": "FunkeCoder23's Repository",
-        "index": 448
-    },
-    {
-        "url": "https://github.com/fuzzy01/unraid_plg_repo",
-        "profile": "https://forums.unraid.net/profile/143886-fuzzy0101/",
-        "title": "Fuzzy0101's Repository",
-        "index": 449
-    },
-    {
-        "url": "https://github.com/ganey/unraid-honeygain",
-        "profile": "https://forums.unraid.net/profile/94003-ganey/",
-        "title": "ganey's Repository",
-        "index": 450
-    },
-    {
-        "url": "https://github.com/Garethp/rolemaster-era-server-unraid",
-        "profile": "https://forums.unraid.net/profile/243895-garethp/",
-        "title": "Garethp's Repository",
-        "index": 451
-    },
-    {
-        "url": "https://github.com/GEngines/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290261-bmetpally/",
-        "title": "GEngines' Repository",
-        "index": 452
-    },
-    {
-        "url": "https://github.com/geoffgbsn/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/144116-geoffgibby/",
-        "title": "geoff.gibby's Repository",
-        "index": 453
-    },
-    {
-        "url": "https://github.com/ghzgod/signal-notification-unraid",
-        "profile": "https://forums.unraid.net/profile/293977-ghzgod11/",
-        "title": "ghzgod11's Repository",
-        "index": 454
-    },
-    {
-        "url": "https://github.com/gibz104/SpoolmanSync",
-        "profile": "https://forums.unraid.net/profile/293978-gibz104/",
-        "title": "gibz104's Repository",
-        "index": 455
-    },
-    {
-        "url": "https://github.com/Gill-Bates/unraid-app-templates",
-        "profile": "https://forums.unraid.net/profile/288881-gillbates/",
-        "title": "GillBates' Repository",
-        "index": 456
-    },
-    {
-        "url": "https://github.com/mecharmor/gog-free-claimer",
-        "profile": null,
-        "title": "GOG Free Games Claimer",
-        "index": 457
-    },
-    {
-        "url": "https://github.com/GoldnGroup/unraid-templates",
-        "profile": null,
-        "title": "GoldnGroup's Repository",
-        "index": 458
-    },
-    {
-        "url": "https://github.com/Goodhall-Solutions-ltd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294974-goodhall-solutions/",
-        "title": "Goodhall Solutions' Repository",
-        "index": 459
-    },
-    {
-        "url": "https://github.com/googleg/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282598-googleg/",
-        "title": "googleg's Repository",
-        "index": 460
-    },
-    {
-        "url": "https://github.com/got3nks/amutorrent",
-        "profile": "https://forums.unraid.net/profile/294555-got3nks/",
-        "title": "got3nks' Repository",
-        "index": 461
-    },
-    {
-        "url": "https://github.com/GregYankovoy/docker-templates",
-        "profile": "https://forums.unraid.net/profile/88760-grack/",
-        "title": "Grack's Repository",
-        "index": 462
-    },
-    {
-        "url": "https://github.com/gameyfin/unraid",
-        "profile": "https://forums.unraid.net/profile/249165-grimsi/",
-        "title": "grimsi's Repository",
-        "index": 463
-    },
-    {
-        "url": "https://github.com/Groestlcoin/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281950-groestlcoin/",
-        "title": "groestlcoin's Repository",
-        "index": 464
-    },
-    {
-        "url": "https://github.com/reloadfast/unraid_template_LibreLinkUp_Uploader",
-        "profile": "https://forums.unraid.net/profile/125005-guillermomg/",
-        "title": "GuillermoMG's Repository",
-        "index": 465
-    },
-    {
-        "url": "https://github.com/HabiRabbu/Musicseerr",
-        "profile": "https://forums.unraid.net/profile/295022-habirabbu/",
-        "title": "HabiRabbu's Repository",
-        "index": 466
-    },
-    {
-        "url": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
-        "profile": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
-        "title": "hedrinbc's Repository",
-        "index": 467
-    },
-    {
-        "url": "https://github.com/helliott20/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/170827-helliott20/",
-        "title": "helliott20's Repository",
-        "index": 468
-    },
-    {
-        "url": "https://github.com/hernandito/docker-templates",
-        "profile": "https://forums.unraid.net/profile/6274-hernandito/",
-        "title": "hernandito's Repository",
-        "index": 469
-    },
-    {
-        "url": "https://github.com/hoody424/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/127129-hoody424/",
-        "title": "hoody424's Repository",
-        "index": 470
-    },
-    {
-        "url": "https://github.com/masterjb/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/124596-human-126094/",
-        "title": "Human-126094's Repository",
-        "index": 471
-    },
-    {
-        "url": "https://github.com/HuxyUK/docker-containers",
-        "profile": "https://forums.unraid.net/profile/70544-huxy/",
-        "title": "Huxy's Repository",
-        "index": 472
-    },
-    {
-        "url": "https://github.com/TheBinaryNinja/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103361-iflip721/",
-        "title": "i.Flip721's Repository",
-        "index": 473
-    },
-    {
-        "url": "https://github.com/ikoyhn/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/128240-ikoyhn/",
-        "title": "ikoyhn's Repository",
-        "index": 474
-    },
-    {
-        "url": "https://github.com/imagegenius/templates",
-        "profile": "https://forums.unraid.net/profile/103573-vcxpz/",
-        "title": "imagegenius' Repository",
-        "index": 475
-    },
-    {
-        "url": "https://github.com/Inch-high/plexgeo",
-        "profile": "https://forums.unraid.net/profile/136949-inch/",
-        "title": "Inch's Repository",
-        "index": 476
-    },
-    {
-        "url": "https://github.com/Indemnity83/always-bring-a-gift",
-        "profile": "https://forums.unraid.net/profile/83781-indemnity83/",
-        "title": "Indemnity83's Repository",
-        "index": 477
-    },
-    {
-        "url": "https://github.com/Infotrend-Inc/CTPO",
-        "profile": "https://forums.unraid.net/profile/256461-infotrend-inc/",
-        "title": "Infotrend Inc's Repository",
-        "index": 478
-    },
-    {
-        "url": "https://github.com/ipdock/unraid-templates",
-        "profile": null,
-        "title": "ipdock's Repository",
-        "index": 479
-    },
-    {
-        "url": "https://github.com/Infotrend-Inc/OpenAI_WebUI",
-        "profile": "https://forums.unraid.net/profile/256461-iti/",
-        "title": "ITI's Repository",
-        "index": 480
-    },
-    {
-        "url": "https://github.com/itimpi/Unraid-CA-Templates",
-        "profile": "https://forums.unraid.net/profile/10897-itimpi/",
-        "title": "itimpi's Repository",
-        "index": 481
-    },
-    {
-        "url": "https://github.com/itsnotashley/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287054-itsnotashley/",
-        "title": "itsnotashley's Repository",
-        "index": 482
-    },
-    {
-        "url": "https://github.com/ngfchl/ptools_unraid_template",
-        "profile": "https://forums.unraid.net/profile/268036-jacksonnie/",
-        "title": "JacksonNie's Repository",
-        "index": 483
-    },
-    {
-        "url": "https://github.com/what-name/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/122982-jacob-bolooni/",
-        "title": "Jacob Bolooni's Repository",
-        "index": 484
-    },
-    {
-        "url": "https://github.com/JACOBSMILE/Unraid_XMLS",
-        "profile": "https://forums.unraid.net/profile/141756-jacobsmile/",
-        "title": "JACOBSMILE's Repository",
-        "index": 485
-    },
-    {
-        "url": "https://github.com/jadehawk/unRaid-Templates",
-        "profile": "https://forums.unraid.net/profile/168612-jadehawk",
-        "title": "Jadehawk's Repository",
-        "index": 486
-    },
-    {
-        "url": "https://github.com/jcoker85/UnraidTemplates",
-        "profile": "https://forums.unraid.net/profile/255902-jamxx/",
-        "title": "Jamxx's Repository",
-        "index": 487
-    },
-    {
-        "url": "https://github.com/jandrop/file_core_api_unraid",
-        "profile": "https://forums.unraid.net/profile/111434-jandrop/",
-        "title": "jandrop's Repository",
-        "index": 488
-    },
-    {
-        "url": "https://github.com/JW-CH/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/268715-janmer/",
-        "title": "janmer's Repository",
-        "index": 489
-    },
-    {
-        "url": "https://github.com/jarvis2f/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284045-jarvis2f/",
-        "title": "jarvis2f's Repository",
-        "index": 490
-    },
-    {
-        "url": "https://github.com/jassycliq/Unraid-AndroidStudio-Projector",
-        "profile": "https://forums.unraid.net/profile/116233-jassycliq/",
-        "title": "jassycliq's Repository",
-        "index": 491
-    },
-    {
-        "url": "https://github.com/jaydenroberts/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/175884-jaydenroberts/",
-        "title": "JaydenRoberts' Repository",
-        "index": 492
-    },
-    {
-        "url": "https://github.com/jbartlett777/DiskSpeed",
-        "profile": "https://forums.unraid.net/profile/8307-jbartlett/",
-        "title": "JBartlett's Repository",
-        "index": 493
-    },
-    {
-        "url": "https://github.com/jbreed/docker-templates",
-        "profile": "https://forums.unraid.net/profile/92695-jbreed/",
-        "title": "jbreed's Repository",
-        "index": 494
-    },
-    {
-        "url": "https://github.com/Jcloud67/Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/67922-jcloud/",
-        "title": "JCloud's Repository",
-        "index": 495
-    },
-    {
-        "url": "https://github.com/jcreynolds/docker-templates",
-        "profile": "https://forums.unraid.net/profile/65204-jcreynoldsii/",
-        "title": "jcreynolds' Repository",
-        "index": 496
-    },
-    {
-        "url": "https://github.com/jjermany/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/288757-jermcee/",
-        "title": "jermcee's Repository",
-        "index": 497
-    },
-    {
-        "url": "https://github.com/jessielw/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/201686-jessielw/",
-        "title": "Jessielw's Repository",
-        "index": 498
-    },
-    {
-        "url": "https://github.com/jflo/ffsync-unraid",
-        "profile": "https://forums.unraid.net/profile/120634-jflo/",
-        "title": "Jflo's Repository",
-        "index": 499
-    },
-    {
-        "url": "https://github.com/GladysAssistant/unraid-gladys-templates",
-        "profile": "https://forums.unraid.net/profile/159169-jgcb00/",
-        "title": "jgcb00's Repository",
-        "index": 500
-    },
-    {
-        "url": "https://github.com/jinlife/docker-templates",
-        "profile": "https://forums.unraid.net/profile/119719-jinlife/",
-        "title": "jinlife's Repository",
-        "index": 501
-    },
-    {
-        "url": "https://github.com/jkirkcaldy/unraid-CA-templates",
-        "profile": "https://forums.unraid.net/profile/114408-jkirkcaldy/",
-        "title": "jkirkcaldy's Repository",
-        "index": 502
-    },
-    {
-        "url": "https://github.com/joch/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/2607-joch/",
-        "title": "joch's Repository",
-        "index": 503
-    },
-    {
-        "url": "https://github.com/johnpwhite/unraid-community-applications-index",
-        "profile": "https://forums.unraid.net/profile/5686-johner/",
-        "title": "johner's Repository",
-        "index": 504
-    },
-    {
-        "url": "https://github.com/b1tsized/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/112763-johnwesturner/",
-        "title": "johnwesturner's Repository",
-        "index": 505
-    },
-    {
-        "url": "https://github.com/Joly0/docker-templates",
-        "profile": "https://forums.unraid.net/profile/86760-joly0/",
-        "title": "joly0's Repository",
-        "index": 506
-    },
-    {
-        "url": "https://github.com/jorgenman/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/142946-jorgenman/",
-        "title": "jorgenman's Repository",
-        "index": 507
-    },
-    {
-        "url": "https://github.com/qubex22/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/110563-joroga22/",
-        "title": "joroga22's Repository",
-        "index": 508
-    },
-    {
-        "url": "https://github.com/josh-gaby/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/171871-joshgaby/",
-        "title": "josh.gaby's Repository",
-        "index": 509
-    },
-    {
-        "url": "https://github.com/Joshndroid/joshndroid-unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/123042-joshndroid/",
-        "title": "Joshndroid's Repository",
-        "index": 510
-    },
-    {
-        "url": "https://github.com/angelics/unraid-docker-template",
-        "profile": "https://forums.unraid.net/profile/7122-josywong/",
-        "title": "josywong's Repository",
-        "index": 511
-    },
-    {
-        "url": "https://github.com/josecoelho/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125944-jos%C3%A9-coelho/",
-        "title": "Jos\u00e9 Coelho's Repository",
-        "index": 512
-    },
-    {
-        "url": "https://github.com/JourneyDocker/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284186-journeyover/",
-        "title": "JourneyOver's Repository",
-        "index": 513
-    },
-    {
-        "url": "https://github.com/JPDVM2014/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/156525-jpdvm2014/",
-        "title": "JPDVM2014's Repository",
-        "index": 514
-    },
-    {
-        "url": "https://github.com/jsatk/unraid-templates",
-        "profile": null,
-        "title": "jsatk's unraid templates",
-        "index": 515
-    },
-    {
-        "url": "https://github.com/jsavargas/telethon_downloader",
-        "profile": "https://forums.unraid.net/profile/93593-jsavargas/",
-        "title": "jsavargas' Repository",
-        "index": 516
-    },
-    {
-        "url": "https://github.com/jterpstra1/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/92505-jterpstra/",
-        "title": "jterpstra's Repository",
-        "index": 517
-    },
-    {
-        "url": "https://github.com/JudoChinX/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287737-judochinx/",
-        "title": "JudoChinX's Repository",
-        "index": 518
-    },
-    {
-        "url": "https://github.com/shaf/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/71085-jugniji/",
-        "title": "JugniJi's Repository",
-        "index": 519
-    },
-    {
-        "url": "https://github.com/JustinAiken/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/1079-justinaiken/",
-        "title": "JustinAiken's Repository",
-        "index": 520
-    },
-    {
-        "url": "https://github.com/Olprog59/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/121454-kameleon83/",
-        "title": "Kameleon83's Repository",
-        "index": 521
-    },
-    {
-        "url": "https://github.com/KasteM34/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169707-kastem34/",
-        "title": "kastem34's Repository",
-        "index": 522
-    },
-    {
-        "url": "https://github.com/keenaanee/CinemaStatus",
-        "profile": "https://forums.unraid.net/profile/271535-keenaanee/",
-        "title": "Keenaanee's Repository",
-        "index": 523
-    },
-    {
-        "url": "https://github.com/roninkenji/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/62359-ken-ji/",
-        "title": "ken-ji's Repository",
-        "index": 524
-    },
-    {
-        "url": "https://github.com/kezzkezzkezz/UNRAID-Templates/",
-        "profile": "https://forums.unraid.net/profile/133849-kezzkezzkezz/",
-        "title": "kezzkezzkezz's Repository",
-        "index": 525
-    },
-    {
-        "url": "https://github.com/kilrah/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/175398-kilrah/",
-        "title": "Kilrah's Repository",
-        "index": 526
-    },
-    {
-        "url": "https://github.com/kiowadriver/unraid-docker",
-        "profile": "https://forums.unraid.net/profile/74645-kiowa2005/",
-        "title": "kiowa2005's Repository",
-        "index": 527
-    },
-    {
-        "url": "https://github.com/Knoxie/UnraidTemplates",
-        "profile": "https://forums.unraid.net/profile/78069-knoxie89/",
-        "title": "Knoxie89's Repository",
-        "index": 528
-    },
-    {
-        "url": "https://github.com/S0CT/fsm",
-        "profile": "https://forums.unraid.net/profile/275440-kognac/",
-        "title": "Kognac's Repository",
-        "index": 529
-    },
-    {
-        "url": "https://github.com/Kostecki/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/68040-kostecki/",
-        "title": "kostecki's Repository",
-        "index": 530
-    },
-    {
-        "url": "https://github.com/Kru-x/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/69435-kru-x/",
-        "title": "Kru-X's Repository",
-        "index": 531
-    },
-    {
-        "url": "https://github.com/Qlisch/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119212-kulisch/",
-        "title": "Kulisch's Repository",
-        "index": 532
-    },
-    {
-        "url": "https://github.com/Kurotaku-sama/Unraid-Plugins-Repository",
-        "profile": "https://forums.unraid.net/profile/277881-kurotaku/",
-        "title": "Kurotaku's Repository",
-        "index": 533
-    },
-    {
-        "url": "https://github.com/kywarai/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/170658-kuuki/",
-        "title": "kuuki's Repository",
-        "index": 534
-    },
-    {
-        "url": "https://github.com/Srcodesalittle/cryptgeon_redis",
-        "profile": "https://forums.unraid.net/profile/131563-lamp/",
-        "title": "lamp's Repository",
-        "index": 535
-    },
-    {
-        "url": "https://github.com/Revise0592/unraid-apps",
-        "profile": null,
-        "title": "Larv's Repository",
-        "index": 536
-    },
-    {
-        "url": "https://github.com/laur89/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/114193-laur/",
-        "title": "laur's Repository",
-        "index": 537
-    },
-    {
-        "url": "https://github.com/laurensguijt/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/254983-laurensguijt/",
-        "title": "Laurensguijt's Repository",
-        "index": 538
-    },
-    {
-        "url": "https://github.com/lawryder/unraid_docker_reps",
-        "profile": "https://forums.unraid.net/profile/122425-lawryder/",
-        "title": "LawRyder's Repository",
-        "index": 539
-    },
-    {
-        "url": "https://github.com/murtaza-nasir/speakr-unraid",
-        "profile": "https://github.com/murtaza-nasir/speakr-unraid",
-        "title": "learnedmachine's Repository",
-        "index": 540
-    },
-    {
-        "url": "https://github.com/lewislarsen/lldap-unraid",
-        "profile": "https://forums.unraid.net/profile/143760-lewis-l/",
-        "title": "Lewis L's Repository",
-        "index": 541
-    },
-    {
-        "url": "https://github.com/L1cardo/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/128967-licardo/",
-        "title": "licardo's Repository",
-        "index": 542
-    },
-    {
-        "url": "https://github.com/linuxserver/linuxserver-Plugin-Repository",
-        "profile": null,
-        "title": "Linuxserver's Plugin Repository",
-        "index": 543
-    },
-    {
-        "url": "https://github.com/liorbass/tandarr-unraid-templates",
-        "profile": null,
-        "title": "LioirBass' Repository",
-        "index": 544
-    },
-    {
-        "url": "https://github.com/locus313/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/74415-locus313/",
-        "title": "locus313's Repository",
-        "index": 545
-    },
-    {
-        "url": "https://github.com/Maitresinh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/280760-logan23/",
-        "title": "logan23's Repository",
-        "index": 546
-    },
-    {
-        "url": "https://github.com/mingzaily/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169573-longyunur/",
-        "title": "LongYunar's Repository",
-        "index": 547
-    },
-    {
-        "url": "https://github.com/Loony2392/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/152355-loony2392/",
-        "bio": "",
-        "icon": "https://raw.githubusercontent.com/Loony2392/unraid-templates/main/icons/avatar.gif",
-        "DonateLink": "https://ko-fi.com/loony_tech",
-        "DonateText": "If you like my work please consider Donating.",
-        "Forum": "https://forums.unraid.net/profile/152355-loony2392/",
-        "title": "Loony2392's Repository",
-        "index": 548
-    },
-    {
-        "url": "https://github.com/timespacedecay/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/121604-lostinspace/",
-        "title": "lostinspace's Repository",
-        "index": 549
-    },
-    {
-        "url": "https://github.com/lucamarchiori/OwnTracksRecorderUnraid",
-        "profile": "https://forums.unraid.net/profile/255135-lucamarchiori/",
-        "title": "lucamarchiori's Repository",
-        "index": 550
-    },
-    {
-        "url": "https://github.com/luisalrp/unraid_docker_templates",
-        "profile": "https://forums.unraid.net/profile/115058-luisalrp/",
-        "title": "luisalrp's Repository",
-        "index": 551
-    },
-    {
-        "url": "https://github.com/lumbeecheraw75/unraid-templates",
-        "profile": null,
-        "title": "lumbeecheraw75's Repository",
-        "index": 552
-    },
-    {
-        "url": "https://github.com/l4rm4nd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279319-lrvt/",
-        "title": "LVRT's Repository",
-        "index": 553
-    },
-    {
-        "url": "https://github.com/macexx/docker-templates",
-        "profile": "https://forums.unraid.net/profile/66302-macester/",
-        "title": "macester's Repository",
-        "index": 554
-    },
-    {
-        "url": "https://github.com/MROGHUB/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282192-mackattack/",
-        "title": "MackAttack's Repository",
-        "index": 555
-    },
-    {
-        "url": "https://github.com/mackid1993/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/74622-mackid1993/",
-        "title": "Mackid1993's Repository",
-        "index": 556
-    },
-    {
-        "url": "https://github.com/jo-sobo/scriptlogs-unraid-plugin",
-        "profile": "https://forums.unraid.net/profile/120452-magnum308/",
-        "title": "Magnum.308's Repository",
-        "index": 557
-    },
-    {
-        "url": "https://github.com/Maikboarder/Playerr",
-        "profile": "https://forums.unraid.net/profile/293293-maikboarder/",
-        "title": "Maikboarder's Repository",
-        "index": 558
-    },
-    {
-        "url": "https://github.com/Malfurious/docker-templates",
-        "profile": "https://forums.unraid.net/profile/77149-malfurious/",
-        "title": "malfurious' Repository",
-        "index": 559
-    },
-    {
-        "url": "https://github.com/malkiebr/unraid-localtonet",
-        "profile": "https://forums.unraid.net/profile/234461-malkie/",
-        "title": "malkie's Repository",
-        "index": 560
-    },
-    {
-        "url": "https://github.com/malvarez00/unRAID-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/77549-malvarez00/",
-        "title": "malvarez00's Repository",
-        "index": 561
-    },
-    {
-        "url": "https://github.com/mandarons/icloud-drive-docker",
-        "profile": "https://forums.unraid.net/profile/278021-mandarons/",
-        "title": "mandarons' Repository",
-        "index": 562
-    },
-    {
-        "url": "https://github.com/PonyLucky/TendaControllerXML",
-        "profile": "https://forums.unraid.net/profile/177818-margot/",
-        "title": "Margot's Repository",
-        "index": 563
-    },
-    {
-        "url": "https://github.com/MarkusMcNugen/docker-templates",
-        "profile": "https://forums.unraid.net/profile/79684-markusmcnugen/",
-        "title": "MarkusMcNugen's Repository",
-        "index": 564
-    },
-    {
-        "url": "https://github.com/Marraz/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/127460-marraz/",
-        "title": "Marraz' Repository",
-        "index": 565
-    },
-    {
-        "url": "https://github.com/mash2k3/unraid-templates",
-        "profile": null,
-        "title": "mash2k3's Repository",
-        "index": 566
-    },
-    {
-        "url": "https://github.com/rantanlan/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/914-mason",
-        "title": "mason's Repository",
-        "index": 567
-    },
-    {
-        "url": "https://github.com/mastiffmushroom/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/243288-mastiffmushroom/",
-        "title": "MastiffMushroom's Repository",
-        "index": 568
-    },
-    {
-        "url": "https://github.com/matda59/video-to-mp3-converter",
-        "profile": "https://forums.unraid.net/profile/119423-matda59/",
-        "title": "matda59's Repository",
-        "index": 569
-    },
-    {
-        "url": "https://github.com/mattheworres/docker-templates",
-        "profile": "https://forums.unraid.net/profile/115370-matthew-orres/",
-        "title": "Matthew Orres' Repository",
-        "index": 570
-    },
-    {
-        "url": "https://github.com/PepaonDrugs/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/157546-maxi_fpv/",
-        "title": "Maxi_Fpv's Repository",
-        "index": 571
-    },
-    {
-        "url": "https://github.com/maybegrim/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294736-maybegrim/",
-        "title": "MaybeGrim's Repository",
-        "index": 572
-    },
-    {
-        "url": "https://github.com/mayo-248/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/175387-mayo_248/",
-        "title": "Mayo_248's Repository",
-        "index": 573
-    },
-    {
-        "url": "https://github.com/mbirnbach/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/291521-mbirnbach/",
-        "title": "mbirnbach's Repository",
-        "index": 574
-    },
-    {
-        "url": "https://github.com/mccann6/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/293805-mccann6/",
-        "title": "mccann6's Repository",
-        "index": 575
-    },
-    {
-        "url": "https://github.com/mcdays94/docker-templates",
-        "profile": null,
-        "title": "mcdays94's Repository",
-        "index": 576
-    },
-    {
-        "url": "https://github.com/McJoppy/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/250622-mcraidy/",
-        "title": "mcraidy's Repository",
-        "index": 577
-    },
-    {
-        "url": "https://github.com/mdarkness1988/rust-server-template",
-        "profile": "https://forums.unraid.net/profile/84443-mdarkness1988/",
-        "title": "mdarkness1988's Repository",
-        "index": 578
-    },
-    {
-        "url": "https://github.com/OctoPrint/Unraid-Template",
-        "profile": "https://forums.unraid.net/profile/100446-mearman",
-        "title": "mearman's 2nd Repository",
-        "index": 579
-    },
-    {
-        "url": "https://github.com/NotExpectedYet/OctoFarm-UnRaid-Template",
-        "profile": "https://forums.unraid.net/profile/100446-mearman",
-        "title": "mearman's Repository",
-        "index": 580
-    },
-    {
-        "url": "https://github.com/mediux-team/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125333-mmoosem/",
-        "title": "Mediux-Team's Repository",
-        "index": 581
-    },
-    {
-        "url": "https://github.com/kiwimato/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/89549-mihai/",
-        "title": "Mihai's Repository",
-        "index": 582
-    },
-    {
-        "url": "https://github.com/helfrichmichael/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/68815-mikeah/",
-        "title": "MikeAH's Repository",
-        "index": 583
-    },
-    {
-        "url": "https://github.com/mikedhanson/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/88846-mikehanson/",
-        "title": "mikehanson's Repository",
-        "index": 584
-    },
-    {
-        "url": "https://github.com/mikeylikesrocks/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/89382-mikeylikesrocks",
-        "title": "mikeylikesrocks' Repository",
-        "index": 585
-    },
-    {
-        "url": "https://github.com/misterjtc/docker-templates",
-        "profile": "https://forums.unraid.net/profile/68425-misterjtc/",
-        "title": "Misterjtc's Repository",
-        "index": 586
-    },
-    {
-        "url": "https://github.com/mizz141/mizz141-unraid-xml",
-        "profile": "https://forums.unraid.net/profile/98815-mizz141/",
-        "title": "Mizz141's Repository",
-        "index": 587
-    },
-    {
-        "url": "https://github.com/m-klecka/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/210341-mklecka/",
-        "title": "mklecka's Repository",
-        "index": 588
-    },
-    {
-        "url": "https://github.com/mlapaglia/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/100043-mlapaglia/",
-        "title": "mlapaglia's Repository",
-        "index": 589
-    },
-    {
-        "url": "https://github.com/mlebjerg/docker-templates",
-        "profile": "https://forums.unraid.net/profile/76816-mlebjerg/",
-        "title": "mlebjerg's Repository",
-        "index": 590
-    },
-    {
-        "url": "https://github.com/MMagTech/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/108975-mmagtech/",
-        "title": "MMagTech's Repository",
-        "index": 591
-    },
-    {
-        "url": "https://github.com/MobiusNine/docker-templates",
-        "profile": "https://forums.unraid.net/profile/84666-mobiusnine/",
-        "title": "MobiusNine's Repository",
-        "index": 592
-    },
-    {
-        "url": "https://github.com/crgodfrey/unraid-froggi",
-        "profile": "https://forums.unraid.net/profile/274467-monkeyss/",
-        "title": "monkeyss' Repository",
-        "index": 593
-    },
-    {
-        "url": "https://github.com/MorgothRB/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/280956-morgoth/",
-        "title": "Morgoth's Repository",
-        "index": 594
-    },
-    {
-        "url": "https://github.com/moritzfl/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145080-moritzf/",
-        "title": "moritzf's Repository",
-        "index": 595
-    },
-    {
-        "url": "https://github.com/mplogas/unraid-containers",
-        "profile": "https://forums.unraid.net/profile/145679-mplogas/",
-        "title": "mplogas' Repository",
-        "index": 596
-    },
-    {
-        "url": "https://github.com/crazyqin/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/157513-mrafter/",
-        "title": "mrafter's Repository",
-        "index": 597
-    },
-    {
-        "url": "https://github.com/dalekseevs/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/74482-mrchunky",
-        "title": "MrChunky's Repository",
-        "index": 598
-    },
-    {
-        "url": "https://github.com/MrCorehh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/293911-mrcorehh/",
-        "title": "MrCorehh's Repository",
-        "index": 599
-    },
-    {
-        "url": "https://github.com/JulienPlomteux/Unraid-ErgoNode",
-        "profile": "https://forums.unraid.net/profile/163009-mrlafontaine/",
-        "title": "mrlafontaine's Repository",
-        "index": 600
-    },
-    {
-        "url": "https://github.com/mstrhakr/plugin-repository",
-        "profile": "https://forums.unraid.net/profile/119750-mstrhakr",
-        "title": "mstrhakr's Repository",
-        "index": 601
-    },
-    {
-        "url": "https://github.com/mtrogman/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/115379-mtrogman/",
-        "title": "mtrogman's Repository",
-        "index": 602
-    },
-    {
-        "url": "https://github.com/Mudislander/docker-templates",
-        "profile": "https://forums.unraid.net/profile/67039-mudislander/",
-        "title": "Mudislander's Repository",
-        "index": 603
-    },
-    {
-        "url": "https://github.com/Muwahhidun/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/107652-muwahhid/",
-        "title": "Muwahhidun's Repository",
-        "index": 604
-    },
-    {
-        "url": "https://github.com/Muxelmann/unraid-app_anaconda3",
-        "profile": "https://forums.unraid.net/profile/238596-muxelmann/",
-        "title": "muxelmann's Repository",
-        "index": 605
-    },
-    {
-        "url": "https://github.com/MyFaith/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/157465-myfaith/",
-        "title": "MyFaith's Repository",
-        "index": 606
-    },
-    {
-        "url": "https://github.com/Nackophilz/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/161066-nackophilz/",
-        "title": "Nackophilz's Repository",
-        "index": 607
-    },
-    {
-        "url": "https://github.com/metronade/unraid-templates",
-        "profile": null,
-        "title": "nade's Repository",
-        "index": 608
-    },
-    {
-        "url": "https://github.com/ne0ark/docker-templates",
-        "profile": "https://forums.unraid.net/profile/221895-naidu/",
-        "title": "Naidu's Repository",
-        "index": 609
-    },
-    {
-        "url": "https://github.com/natcoso9955/unRAID-docker",
-        "profile": "https://forums.unraid.net/profile/73128-natcoso9955/",
-        "title": "Natcoso9955's Repository",
-        "index": 610
-    },
-    {
-        "url": "https://github.com/NebN/unraid-apps",
-        "profile": "https://forums.unraid.net/profile/274578-nebn/",
-        "title": "NebN's Repository",
-        "index": 611
-    },
-    {
-        "url": "https://github.com/nebula-codes/hytale_server_manager",
-        "profile": "https://forums.unraid.net/profile/293434-nebulacodes/",
-        "title": "Nebula's Repository",
-        "index": 612
-    },
-    {
-        "url": "https://github.com/netpersona/popcorn-unraid",
-        "profile": "https://forums.unraid.net/profile/234637-smackmybones/",
-        "title": "Netpersona's Repository",
-        "index": 613
-    },
-    {
-        "url": "https://github.com/neur0map/deskmon-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/294130-neur0map/",
-        "title": "Neur0map's Repository",
-        "index": 614
-    },
-    {
-        "url": "https://github.com/JFLXCLOUD/NeXroll",
-        "profile": null,
-        "title": "NeXroll's Repository",
-        "index": 615
-    },
-    {
-        "url": "https://github.com/NickBorgers/unraid-apps",
-        "profile": "https://forums.unraid.net/profile/69750-nickborgers/",
-        "title": "Nick Borgers' Repository",
-        "index": 616
-    },
-    {
-        "url": "https://github.com/NickBootOne/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/93263-nickboot/",
-        "title": "nickboot's Repository",
-        "index": 617
-    },
-    {
-        "url": "https://github.com/NixonInnes/unraid-builds-xml",
-        "profile": "https://forums.unraid.net/profile/122748-nixoninnes/",
-        "title": "NixonInnes' Repository",
-        "index": 618
-    },
-    {
-        "url": "https://github.com/MitchellThompkins/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285040-not_a_real_human/",
-        "title": "not_a_real_human's Repository",
-        "index": 619
-    },
-    {
-        "url": "https://github.com/NSPManager/NSPanelManager",
-        "profile": null,
-        "title": "NSPManager's Repository",
-        "index": 620
-    },
-    {
-        "url": "https://github.com/nullata/unraid-images",
-        "profile": "https://forums.unraid.net/profile/229913-nullata/",
-        "title": "nullata's Repository",
-        "index": 621
-    },
-    {
-        "url": "https://github.com/nylonee/watchlistarr-unraid",
-        "profile": "https://forums.unraid.net/profile/142159-nylonee/",
-        "title": "nylonee's Repository",
-        "index": 622
-    },
-    {
-        "url": "https://github.com/nyxtron/unraid-templates",
-        "profile": null,
-        "title": "Nyxtron's Repository",
-        "index": 623
-    },
-    {
-        "url": "https://github.com/ObviousViking/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/114882-obviousviking/",
-        "title": "ObviousViking's Repository",
-        "index": 624
-    },
-    {
-        "url": "https://github.com/OFark/docker-templates",
-        "profile": "https://forums.unraid.net/profile/86513-ofark/",
-        "title": "OFark's Repository",
-        "index": 625
-    },
-    {
-        "url": "https://github.com/ofawx/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/109310-ofawx/",
-        "title": "ofawx's Repository",
-        "index": 626
-    },
-    {
-        "url": "https://github.com/plexinc/pms-docker",
-        "profile": null,
-        "shortName": "Plex",
-        "title": "Official Plex Repository",
-        "index": 627
-    },
-    {
-        "url": "https://github.com/ijabz/songkong_unraid/",
-        "profile": null,
-        "shortName": "Songkong",
-        "title": "Official Songkong Repository",
-        "index": 628
-    },
-    {
-        "url": "https://github.com/unraid/docker-templates",
-        "profile": null,
-        "shortName": "Unraid",
-        "title": "Official Unraid Plugin Repository",
-        "index": 629
-    },
-    {
-        "url": "https://github.com/wizarrrr/wizarr",
-        "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
-        "title": "Official Wizarr Repository",
-        "index": 630
-    },
-    {
-        "url": "https://github.com/oldcrazyeye/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/124305-oldcrazyeye/",
-        "title": "oldcrazyeye's Repository",
-        "index": 631
-    },
-    {
-        "url": "https://github.com/0neTX/UnRAID_Template",
-        "profile": "https://forums.unraid.net/profile/161660-onetx/",
-        "title": "onetx's Repository",
-        "index": 632
-    },
-    {
-        "url": "https://github.com/opal06/unraid_docker_templates",
-        "profile": "https://forums.unraid.net/profile/110756-opal_06/",
-        "title": "opal_06's Repository",
-        "index": 633
-    },
-    {
-        "url": "https://github.com/openspeedtest/unraid-docker-plugin",
-        "profile": "https://forums.unraid.net/profile/110999-openspeedtest/",
-        "title": "openspeedtest's Repository",
-        "index": 634
-    },
-    {
-        "url": "https://github.com/orangecoding/fredy-unraid-template",
-        "profile": "https://forums.unraid.net/profile/292517-orangecoding/",
-        "title": "Orangecoding's Repository",
-        "index": 635
-    },
-    {
-        "url": "https://github.com/pacnpal/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/263235-pacnpal/",
-        "title": "pacnpal's Repository",
-        "index": 636
-    },
-    {
-        "url": "https://github.com/theodorecharles/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103598-paloooz/",
-        "title": "paloooz's Repository",
-        "index": 637
-    },
-    {
-        "url": "https://github.com/ruaan-deysel/unraid-apps",
-        "profile": "https://forums.unraid.net/profile/98076-panicmechanic007/",
-        "title": "PanicMechanic007's Repository",
-        "index": 638
-    },
-    {
-        "url": "https://github.com/PartitionPixel/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119008-partition-pixel/",
-        "title": "Partition Pixel's Repository",
-        "index": 639
-    },
-    {
-        "url": "https://github.com/patrickstigler/unraid_app_templates",
-        "profile": "https://forums.unraid.net/profile/139758-maddash1337/",
-        "title": "patrickstigler's Repository",
-        "index": 640
-    },
-    {
-        "url": "https://github.com/pawelmalak/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/119205-paululibro/",
-        "title": "paululibro's Repository",
-        "index": 641
-    },
-    {
-        "url": "https://github.com/pducharme/docker-containers",
-        "profile": "https://forums.unraid.net/profile/62479-pducharme/",
-        "title": "pducharme's Repository",
-        "index": 642
-    },
-    {
-        "url": "https://github.com/Petelombardo/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/293917-pete-l/",
-        "title": "Pete L's Repository",
-        "index": 643
-    },
-    {
-        "url": "https://github.com/mpcdigitize/docker-templates",
-        "profile": "https://forums.unraid.net/profile/249625-petel/",
-        "title": "PeteL's Repository",
-        "index": 644
-    },
-    {
-        "url": "https://github.com/phyzical/UnraidPlugins",
-        "profile": "https://forums.unraid.net/profile/97031-phyzical/",
-        "title": "phyzical's Repository",
-        "index": 645
-    },
-    {
-        "url": "https://github.com/Piratkopia13/unraid-buddybackup",
-        "profile": "https://forums.unraid.net/profile/158066-pirat/",
-        "title": "Pirat's Repository",
-        "index": 646
-    },
-    {
-        "url": "https://github.com/Uloga1/pre-seederr",
-        "profile": "https://forums.unraid.net/profile/264035-pirlet/",
-        "title": "pirlet's Repository",
-        "index": 647
-    },
-    {
-        "url": "https://github.com/silkyclouds/PMDA_unraid_xml",
-        "profile": "https://forums.unraid.net/profile/170800-meaning/",
-        "title": "PMDA's Repository",
-        "index": 648
-    },
-    {
-        "url": "https://github.com/poke0/Unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/139781-poke0/",
-        "title": "Poke0's Repository",
-        "index": 649
-    },
-    {
-        "url": "https://github.com/benjaminRoberts01375/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290281-preposterous/",
-        "title": "Preposterous' Repository",
-        "index": 650
-    },
-    {
-        "url": "https://github.com/dcflachs/plugin-repository",
-        "profile": "https://forums.unraid.net/profile/63584-primeval_god/",
-        "title": "primeval_god's Repository",
-        "index": 651
-    },
-    {
-        "url": "https://github.com/killforby/chibisafe",
-        "profile": "https://forums.unraid.net/profile/229087-professeurx/",
-        "title": "professeurx's Repository",
-        "index": 652
-    },
-    {
-        "url": "https://github.com/Progeny42/unRAID-CA-Templates",
-        "profile": "https://forums.unraid.net/profile/101997-progeny42",
-        "title": "Progeny42's Repository",
-        "index": 653
-    },
-    {
-        "url": "https://github.com/justjoseorg/Unraid-Intel_Ollama",
-        "profile": "https://forums.unraid.net/profile/261082-possessive-small6053/",
-        "title": "progressive-small6053's Repository",
-        "index": 654
-    },
-    {
-        "url": "https://github.com/ProphetSe7en/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/89667-prophetse7en/",
-        "title": "ProphetSe7en's Repository",
-        "index": 655
-    },
-    {
-        "url": "https://github.com/Pross/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/164140-pross/",
-        "title": "pross' Repository",
-        "index": 656
-    },
-    {
-        "url": "https://github.com/ptchernegovski/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/99869-ptchernegovski/",
-        "title": "ptchernegovski's Repository",
-        "index": 657
-    },
-    {
-        "url": "https://github.com/OctoEverywhere/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/289064-quinninator/",
-        "title": "Quinninator's Repository",
-        "index": 658
-    },
-    {
-        "url": "https://github.com/kikootwo/ReadMeABook",
-        "profile": "https://forums.unraid.net/profile/293929-kikootwo/",
-        "title": "ReadMeABook's Repository",
-        "index": 659
-    },
-    {
-        "url": "https://github.com/picthor-io/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/106558-realcnbs/",
-        "title": "realcnbs' Repository",
-        "index": 660
-    },
-    {
-        "url": "https://github.com/DavidWJR/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/253276-reggieswag/",
-        "title": "ReggieSwag's Repository",
-        "index": 661
-    },
-    {
-        "url": "https://github.com/Michuelnik/docker-mediathekview-web",
-        "profile": "https://forums.unraid.net/profile/153213-revan335/",
-        "title": "Reven335's Repository",
-        "index": 662
-    },
-    {
-        "url": "https://github.com/R3yn4ld/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/77730-reynald/",
-        "title": "Reynald's Repository",
-        "index": 663
-    },
-    {
-        "url": "https://github.com/rezo552/unraid-ltfs/",
-        "profile": "https://forums.unraid.net/profile/271555-rezo552/",
-        "title": "ReZo552's Repository",
-        "index": 664
-    },
-    {
-        "url": "https://github.com/wger-project/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/118956-rge/",
-        "title": "rge's Repository",
-        "index": 665
-    },
-    {
-        "url": "https://github.com/Richy1989/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125824-richy1989/",
-        "title": "Richy1989's Repository",
-        "index": 666
-    },
-    {
-        "url": "http://github.com/RiDDiX/uraid-templates",
-        "profile": "https://forums.unraid.net/profile/123957-riddix/",
-        "title": "RiDDiX's Repository",
-        "index": 667
-    },
-    {
-        "url": "https://github.com/riffsphereha/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/250924-riffsphereha/",
-        "title": "RiffSphereHA's Repository",
-        "index": 668
-    },
-    {
-        "url": "https://github.com/ibigsnet/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/76488-riflejock/",
-        "title": "RifleJock's Repository",
-        "index": 669
-    },
-    {
-        "url": "https://github.com/ripleyXLR8/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/101434-ripleyxlr8/",
-        "title": "ripleyxlr8's Repository",
-        "index": 670
-    },
-    {
-        "url": "https://github.com/Ratomas/CA_XML",
-        "profile": "https://forums.unraid.net/profile/85867-robert-thomas/",
-        "title": "Robert Thomas' Repository",
-        "index": 671
-    },
-    {
-        "url": "https://github.com/RobertCajun/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285092-robertcajun/",
-        "title": "RobertCajun's Repository",
-        "index": 672
-    },
-    {
-        "url": "https://github.com/RoBro92/fanbridge-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290531-robro92/",
-        "title": "RoBro92's Repository",
-        "index": 673
-    },
-    {
-        "url": "https://github.com/roflcoopter/viseron-unraid-ca-template",
-        "profile": "https://forums.unraid.net/profile/113120-roflcoopter",
-        "title": "roflcoopter's Repository",
-        "index": 674
-    },
-    {
-        "url": "https://github.com/kennethprose/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/174044-roseatoni/",
-        "title": "roseatoni's Repository",
-        "index": 675
-    },
-    {
-        "url": "https://github.com/cloud-fs/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/261359-rotten-pagoda5238/",
-        "title": "rotten-pagoda5238's Repository",
-        "index": 676
-    },
-    {
-        "url": "https://github.com/rohit-purandare/ShelfBridge-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283015-rpurandare/",
-        "title": "rpurandare's Repository",
-        "index": 677
-    },
-    {
-        "url": "https://github.com/Saetron/unRAID-CA-templates",
-        "profile": "https://forums.unraid.net/profile/290584-saetron/",
-        "title": "saetron's Repository",
-        "index": 678
-    },
-    {
-        "url": "https://github.com/czerus/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/277784-sajnti/",
-        "title": "sajnti's Repository",
-        "index": 679
-    },
-    {
-        "url": "https://github.com/SAL-e/docker-templates",
-        "profile": "https://forums.unraid.net/profile/11345-sal-e/",
-        "title": "SAL-e's Repository",
-        "index": 680
-    },
-    {
-        "url": "https://github.com/sam10155/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/116626-sam10155/",
-        "title": "sam10155's Repository",
-        "index": 681
-    },
-    {
-        "url": "https://github.com/SamTV12345/podfetch-unraid-config",
-        "profile": "https://forums.unraid.net/profile/261451-samtv12345/",
-        "title": "SamTV12345's Repository",
-        "index": 682
-    },
-    {
-        "url": "https://github.com/kroeberd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/291694-sarcasm/",
-        "title": "sarcasm's Repository",
-        "index": 683
-    },
-    {
-        "url": "https://github.com/SasaKaranovic/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/273010-sasakaranovic/",
-        "title": "SasaKaranovic's Repository",
-        "index": 684
-    },
-    {
-        "url": "https://github.com/SavageAUS/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/91260-savageaus/",
-        "title": "SaveageAUS' Repository",
-        "index": 685
-    },
-    {
-        "url": "https://github.com/sebastienvermeille/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/122183-sbeex/",
-        "title": "sbeex's Repository",
-        "index": 686
-    },
-    {
-        "url": "https://github.com/scolcipitato/plugin-repository",
-        "profile": "https://forums.unraid.net/profile/109953-scolcipitato/",
-        "title": "scolcipitato's Repository",
-        "index": 687
-    },
-    {
-        "url": "https://github.com/SuFxGIT/scoutarr",
-        "profile": "https://forums.unraid.net/profile/293114-sufxur/",
-        "title": "Scoutarr's Repository",
-        "index": 688
-    },
-    {
-        "url": "https://github.com/Berrysekk/Script-Dashboard",
-        "profile": null,
-        "title": "Script Dashboard",
-        "index": 689
-    },
-    {
-        "url": "https://github.com/SCUR0/Unraid_Docker_Locust",
-        "profile": "https://forums.unraid.net/profile/274107-scuro/",
-        "title": "Scuro's Repository",
-        "index": 690
-    },
-    {
-        "url": "https://github.com/sdesbure/docker-containers",
-        "profile": "https://forums.unraid.net/profile/3477-sdesbure/",
-        "title": "sdesbure's Repository",
-        "index": 691
-    },
-    {
-        "url": "https://github.com/KodCloud-dev/unraid_template",
-        "profile": "https://forums.unraid.net/profile/255377-sealnado/",
-        "title": "sealnado's Repository",
-        "index": 692
-    },
-    {
-        "url": "https://github.com/sebtech33/unRAID-Templates",
-        "profile": "https://forums.unraid.net/profile/98806-sebtech33/",
-        "title": "SebTech33's Repository",
-        "index": 693
-    },
-    {
-        "url": "https://github.com/secretlycarl/onboarderr-unraid",
-        "profile": "https://forums.unraid.net/profile/289747-secretlycarl/",
-        "title": "SecretlyCarl's Repository",
-        "index": 694
-    },
-    {
-        "url": "https://github.com/dersimn/docker-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/11673-seim/",
-        "title": "seim's Repository",
-        "index": 695
-    },
-    {
-        "url": "https://github.com/sems/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/168805-sem/",
-        "title": "sem's Repository",
-        "index": 696
-    },
-    {
-        "url": "https://github.com/sftpmalin/Media-Remote-Convert",
-        "profile": null,
-        "title": "SftpMalin FFmpeg's Repository",
-        "index": 697
-    },
-    {
-        "url": "https://github.com/TheRealShadoh/babel",
-        "profile": "https://forums.unraid.net/profile/93754-shadoh/",
-        "title": "shadoh's Repository",
-        "index": 698
-    },
-    {
-        "url": "https://github.com/jakemoura/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/118681-jakemoura/",
-        "title": "shaksiwnl's Repository",
-        "index": 699
-    },
-    {
-        "url": "https://github.com/Shaneee/system-monitor",
-        "profile": "https://forums.unraid.net/profile/290974-shaneee92/",
-        "title": "Shaneee's Repository",
-        "index": 700
-    },
-    {
-        "url": "https://github.com/shrmnk/docker-templates",
-        "profile": "https://forums.unraid.net/profile/77786-shrmn/",
-        "title": "shrmn's Repository",
-        "index": 701
-    },
-    {
-        "url": "https://github.com/sidkapahi/curatarr",
-        "profile": "https://forums.unraid.net/profile/295114-sidkapahi/",
-        "title": "sidkapahi's Repository",
-        "index": 702
-    },
-    {
-        "url": "https://github.com/silman/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/163023-silman/",
-        "title": "silman's Repository",
-        "index": 703
-    },
-    {
-        "url": "https://github.com/SimonFair/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/75917-simonf",
-        "title": "SimonF's Repository",
-        "index": 704
-    },
-    {
-        "url": "https://github.com/GotAnAccount/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/187798-simpleserver/",
-        "title": "simpleServer's Repository",
-        "index": 705
-    },
-    {
-        "url": "https://github.com/simse/docker-templates",
-        "profile": "https://forums.unraid.net/profile/69400-simse/",
-        "title": "simse's Repository",
-        "index": 706
-    },
-    {
-        "url": "https://github.com/SiwatINC/unraid-ca-repository",
-        "profile": "https://forums.unraid.net/profile/72489-siwat2545/",
-        "title": "Siwat2545's Repository",
-        "index": 707
-    },
-    {
-        "url": "https://github.com/Skitals/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/97624-skitals/",
-        "title": "Skitals Repository",
-        "index": 708
-    },
-    {
-        "url": "https://github.com/SlrG/unRAID",
-        "profile": "https://forums.unraid.net/profile/16166-slrg/",
-        "title": "SlrG's Repository",
-        "index": 709
-    },
-    {
-        "url": "https://github.com/snapcrescent/templates",
-        "profile": "https://forums.unraid.net/profile/226383-navalgandhi1989/",
-        "title": "snapcrescent's Repository",
-        "index": 710
-    },
-    {
-        "url": "https://github.com/devdems/unraid",
-        "profile": "https://forums.unraid.net/profile/26537-snoopy86/",
-        "title": "snoopy86's Repository",
-        "index": 711
-    },
-    {
-        "url": "https://github.com/snuffomega/docker_unraid_templates",
-        "profile": "https://forums.unraid.net/profile/258583-snuffomega/",
-        "title": "snuffomega's Repository",
-        "index": 712
-    },
-    {
-        "url": "https://github.com/SnuK87/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285383-snuk/",
-        "title": "Snuk's Repository",
-        "index": 713
-    },
-    {
-        "url": "https://github.com/soultaco83/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/87407-soultaco83/",
-        "title": "soultaco83's Repository",
-        "index": 714
-    },
-    {
-        "url": "https://github.com/jamcalli/pulsarr-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/286940-sp00ks/",
-        "title": "sp00ks' Repository",
-        "index": 715
-    },
-    {
-        "url": "https://github.com/SpaceinvaderOne/Docker-Templates-Unraid",
-        "profile": "https://forums.unraid.net/profile/67288-spaceinvaderone/",
-        "title": "SpaceInvaderOne's Repository",
-        "index": 716
-    },
-    {
-        "url": "https://github.com/spants/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/2148-spants/",
-        "title": "Spants' Repository",
-        "index": 717
-    },
-    {
-        "url": "https://github.com/Spikhalskiy/docker-templates",
-        "profile": "https://forums.unraid.net/profile/82549-dmitry-spikhalskiy/",
-        "title": "Spikhalskiy's Repository",
-        "index": 718
-    },
-    {
-        "url": "https://github.com/Staffwerke/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/248178-staffwerke-gmbh/",
-        "title": "Staffwerke GmbH's Repository",
-        "index": 719
-    },
-    {
-        "url": "https://github.com/Steini1984/steini1984-s-repositoy",
-        "profile": "https://forums.unraid.net/profile/2957-steini84/",
-        "title": "steini84's Repository",
-        "index": 720
-    },
-    {
-        "url": "https://github.com/npmSteven/Unraid-VM-CP",
-        "profile": "https://forums.unraid.net/profile/102900-stevenrafferty/",
-        "title": "StevenRafferty's Repository",
-        "index": 721
-    },
-    {
-        "url": "https://github.com/storkenlorken/birdview",
-        "profile": null,
-        "title": "StorkenLorken's Repository",
-        "index": 722
-    },
-    {
-        "url": "https://github.com/bstottle/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/225-stottle/",
-        "title": "stottle's Repository",
-        "index": 723
-    },
-    {
-        "url": "https://github.com/strike84/DiskSpaceManagement-template",
-        "profile": "https://forums.unraid.net/profile/63311-strike/",
-        "title": "strike's Repository",
-        "index": 724
-    },
-    {
-        "url": "https://github.com/stuckless/unRAID",
-        "profile": "https://forums.unraid.net/profile/70058-stuckless/",
-        "title": "stuckless' Repository",
-        "index": 725
-    },
-    {
-        "url": "https://github.com/Sabreu/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/98837-sublivion/",
-        "title": "sublivion's Repository",
-        "index": 726
-    },
-    {
-        "url": "https://github.com/suitux/tagr-unraid",
-        "profile": "https://forums.unraid.net/profile/294950-suitux/",
-        "title": "suitux's Repository",
-        "index": 727
-    },
-    {
-        "url": "https://github.com/skrashevich/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/198957-svk/",
-        "icon": "https://avatars.githubusercontent.com/u/15078499?v=4",
-        "WebPage": "https://github.com/skrashevich",
-        "title": "svk's Repository",
-        "index": 728
-    },
-    {
-        "url": "https://github.com/sworcery/mem-zero",
-        "profile": null,
-        "title": "sworcery's 2nd Repository",
-        "index": 729
-    },
-    {
-        "url": "https://github.com/sworcery/ChannelHoarder",
-        "profile": "https://forums.unraid.net/profile/99321-sworcery/",
-        "title": "sworcery's Repository",
-        "index": 730
-    },
-    {
-        "url": "https://github.com/maxcerny/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/93919-sysco/",
-        "title": "sysco's Repository",
-        "index": 731
-    },
-    {
-        "url": "https://github.com/T4s3rF4c3/macreplay_v2",
-        "profile": "https://forums.unraid.net/profile/150938-t4s3rf4c3/",
-        "title": "T4s3rF4c3's Repository",
-        "index": 732
-    },
-    {
-        "url": "https://github.com/tajniak81/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/98215-tajniak81/",
-        "title": "Tajniak81's Repository",
-        "index": 733
-    },
-    {
-        "url": "https://github.com/kuroki-kael/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283413-tatseo/",
-        "title": "tatseo's Repository",
-        "index": 734
-    },
-    {
-        "url": "https://github.com/Tautulli/Tautulli-Unraid-Template",
-        "profile": "https://forums.unraid.net/profile/69064-wreave/",
-        "title": "Tautulli's Repository",
-        "index": 735
-    },
-    {
-        "url": "https://github.com/schartrand77/makerworks-unraid-templates",
-        "profile": null,
-        "title": "techpunk's repo",
-        "index": 736
-    },
-    {
-        "url": "https://github.com/softerfish/seekandwatch",
-        "profile": "https://forums.unraid.net/profile/283725-tenletters/",
-        "title": "tenletter's Repository",
-        "index": 737
-    },
-    {
-        "url": "https://github.com/Terebi42/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/252870-terebi/",
-        "title": "Terebi's Repository",
-        "index": 738
-    },
-    {
-        "url": "https://github.com/testdasi/testdasi-unraid-repo",
-        "profile": "https://forums.unraid.net/profile/70144-testdasi",
-        "title": "testdasi's Repository",
-        "index": 739
-    },
-    {
-        "url": "https://github.com/jl94x4/ColleXions-WebUI",
-        "profile": "https://forums.unraid.net/profile/270097-thatja/",
-        "title": "thatja's Repository",
-        "index": 740
-    },
-    {
-        "url": "https://github.com/THESHULK/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/237924-the_shulk/",
-        "title": "THE_SHULK's Repository",
-        "index": 741
-    },
-    {
-        "url": "https://github.com/thedinz/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145818-thedinz/",
-        "title": "thedinz' Repository",
-        "index": 742
-    },
-    {
-        "url": "https://github.com/theimmortal68/zappiti-server-docker",
-        "profile": "https://forums.unraid.net/profile/67130-theimmortal/",
-        "title": "theimmortal's Repository",
-        "index": 743
-    },
-    {
-        "url": "https://github.com/jlightner86/jellylooter",
-        "profile": "https://forums.unraid.net/profile/287631-thepizzaninja86/",
-        "title": "ThePizzaNinja86's Repository",
-        "index": 744
-    },
-    {
-        "url": "https://github.com/Th0masDB/unraid_template",
-        "profile": "https://forums.unraid.net/profile/126905-thomasdb__/",
-        "title": "ThomasDB's Repository",
-        "index": 745
-    },
-    {
-        "url": "https://github.com/tynor88/docker-templates",
-        "profile": "https://forums.unraid.net/profile/70206-thomast_88/",
-        "title": "thomast_88's Repository",
-        "index": 746
-    },
-    {
-        "url": "https://github.com/Thraxis/docker-templates",
-        "profile": "https://forums.unraid.net/profile/9802-thraxis/",
-        "title": "Thraxis' Repository",
-        "index": 747
-    },
-    {
-        "url": "https://github.com/timstephens24/docker-templates",
-        "profile": "https://forums.unraid.net/profile/67918-timstephens24/",
-        "title": "timstephens24's Repository",
-        "index": 748
-    },
-    {
-        "url": "https://github.com/tinglis1/docker-containers",
-        "profile": "https://forums.unraid.net/profile/6492-tinglis1/",
-        "title": "tinglis1's Repository",
-        "index": 749
-    },
-    {
-        "url": "https://github.com/tombowditch/docker-templates",
-        "profile": "https://forums.unraid.net/profile/80184-tombowditch/",
-        "title": "tombowditch's Repository",
-        "index": 750
-    },
-    {
-        "url": "https://github.com/T-Eberle/unraid-community-apps",
-        "profile": "https://forums.unraid.net/profile/289970-tommy_e/",
-        "title": "Tommy_E's Repository",
-        "index": 751
-    },
-    {
-        "url": "https://github.com/tommyvange/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282469-tommyvange/",
-        "title": "tommyvange's Repository",
-        "index": 752
-    },
-    {
-        "url": "https://github.com/tophat17/jelly-request",
-        "profile": "https://forums.unraid.net/profile/172432-tophat17/",
-        "title": "TopHat17's Repository",
-        "index": 753
-    },
-    {
-        "url": "https://github.com/tritones/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/172136-tritones/",
-        "title": "tritones' Repository",
-        "index": 754
-    },
-    {
-        "url": "https://github.com/TrophyBuck/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/140258-trophybuck/",
-        "title": "TrophyBuck's Repository",
-        "index": 755
-    },
-    {
-        "url": "https://github.com/tschoerk/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/273668-tschoerk/",
-        "title": "tschoerk's Repository",
-        "index": 756
-    },
-    {
-        "url": "https://github.com/Twingate-Community/unraid-template",
-        "profile": "https://forums.unraid.net/profile/289418-twingate-andrewb/",
-        "title": "Twingate Community's Repository",
-        "index": 757
-    },
-    {
-        "url": "https://github.com/NicolasHaas/unraid-xml-templates",
-        "profile": "https://forums.unraid.net/profile/110262-twixii/",
-        "title": "Twixii's Repository",
-        "index": 758
-    },
-    {
-        "url": "https://github.com/Tylan/Unraid",
-        "profile": null,
-        "title": "Tylan's Repository",
-        "index": 759
-    },
-    {
-        "url": "https://github.com/type0dev/Unraid-Template",
-        "profile": "https://forums.unraid.net/profile/275726-type0dev/",
-        "title": "type0dev's Repository",
-        "index": 760
-    },
-    {
-        "url": "https://github.com/TypingPenguin/docker-templates",
-        "profile": "https://forums.unraid.net/profile/283235-typingpenguin/",
-        "title": "TypingPenguin's Repository",
-        "index": 761
-    },
-    {
-        "url": "https://github.com/charlescng/docker-containers",
-        "profile": "https://forums.unraid.net/profile/64811-uberchuckie/",
-        "title": "uberchuckie's Repository",
-        "index": 762
-    },
-    {
-        "url": "https://github.com/BabaBooey84/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/7743-uderzo/",
-        "title": "Uderzo's Repository",
-        "index": 763
-    },
-    {
-        "url": "https://github.com/Poag/docker-xml",
-        "profile": "https://forums.unraid.net/profile/63933-uirel/",
-        "title": "Uirel's Repository",
-        "index": 764
-    },
-    {
-        "url": "https://github.com/Ulisses1478/templates-unraid",
-        "profile": "https://forums.unraid.net/profile/90485-ulisses1478/",
-        "title": "ulisses1478's Repository",
-        "index": 765
-    },
-    {
-        "url": "https://github.com/undead-reaper/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
-        "title": "Undead Reaper's Repository",
-        "index": 766
-    },
-    {
-        "url": "https://github.com/Unlearned6688/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/170061-unjustice/",
-        "title": "UnJustice's Repository",
-        "index": 767
-    },
-    {
-        "url": "https://github.com/zip-fa/unraid-torrserver",
-        "profile": "https://forums.unraid.net/profile/280443-unraidnewbie2211/",
-        "title": "UnraidNewbie2211's Repository",
-        "index": 768
-    },
-    {
-        "url": "https://github.com/untraceablez/uvdesk-unraid",
-        "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
-        "title": "untraceablez' Repository",
-        "index": 769
-    },
-    {
-        "url": "https://github.com/untraceablez/unraid-apps/",
-        "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
-        "title": "untraceablez's Repository",
-        "index": 770
-    },
-    {
-        "url": "https://github.com/UnToobed/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/160182-unusmundus/",
-        "title": "UnusMundus' Repository",
-        "index": 771
-    },
-    {
-        "url": "https://github.com/sbondCo/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/274118-unwieldy_dingy/",
-        "title": "unwieldy_dingy's Repository",
-        "index": 772
-    },
-    {
-        "url": "https://github.com/GHJJ123/brainrotguard",
-        "profile": "https://forums.unraid.net/profile/100435-ur-jay/",
-        "title": "UR-jay's Repository",
-        "index": 773
-    },
-    {
-        "url": "https://github.com/vwdewaal/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145081-vannie78/",
-        "title": "vannie78's Repository",
-        "index": 774
-    },
-    {
-        "url": "https://github.com/vanshady/unraid-templates",
-        "profile": null,
-        "title": "vanshady's Repository",
-        "index": 775
-    },
-    {
-        "url": "https://github.com/Vilhjalmr26/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/126802-vilhjalmr/",
-        "title": "Vilhjalmr's Repository",
-        "index": 776
-    },
-    {
-        "url": "https://github.com/vincentmakes/cv-manager",
-        "profile": "https://forums.unraid.net/profile/292228-vincentmakes/",
-        "title": "vincentmakes' Repository",
-        "index": 777
-    },
-    {
-        "url": "https://github.com/vLX42/backdrop-generator",
-        "profile": "https://forums.unraid.net/profile/288463-vlx42/",
-        "title": "vlx42's Repository",
-        "index": 778
-    },
-    {
-        "url": "https://github.com/taha-yassine/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/248389-vodros/",
-        "title": "Vodros' Repository",
-        "index": 779
-    },
-    {
-        "url": "https://github.com/vonhex/unraid-templates",
-        "profile": null,
-        "title": "Vonhex's Repository",
-        "index": 780
-    },
-    {
-        "url": "https://github.com/waazaa-fr/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/132702-waazaa/",
-        "title": "waazaa's Repository",
-        "index": 781
-    },
-    {
-        "url": "https://github.com/WaffleMaster22/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/278326-waffle22/",
-        "title": "Waffle22's Repository",
-        "index": 782
-    },
-    {
-        "url": "https://github.com/warieon/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/240351-warieon/",
-        "title": "warieon's Repository",
-        "index": 783
-    },
-    {
-        "url": "https://github.com/SuFxGIT/whatseerr",
-        "profile": "https://forums.unraid.net/profile/293114-sufxur/",
-        "title": "Whatseerr's Repository",
-        "index": 784
-    },
-    {
-        "url": "https://github.com/WhydahGally/docker-templates",
-        "profile": null,
-        "title": "WhydahGally's Repository",
-        "index": 785
-    },
-    {
-        "url": "https://github.com/Receipt-Wrangler/receipt-wrangler-unraid",
-        "profile": "https://forums.unraid.net/profile/268018-wrangler/",
-        "title": "wrangler's Repository",
-        "index": 786
-    },
-    {
-        "url": "https://github.com/WuSiYu/unraid-ca-xml/",
-        "profile": "https://forums.unraid.net/profile/175574-wu23333/",
-        "title": "Wu23333's Repository",
-        "index": 787
-    },
-    {
-        "url": "https://github.com/xavier-hernandez/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/158924-xavierh/",
-        "title": "xavierh's Repository",
-        "index": 788
-    },
-    {
-        "url": "https://github.com/alexphillips-dev/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/122915-xcrownedclownsx/",
-        "title": "XCrownedClownsX's Repository",
-        "index": 789
-    },
-    {
-        "url": "https://github.com/xenco/docker-templates",
-        "profile": "https://forums.unraid.net/profile/155847-xenco/",
-        "title": "xenco's Repository",
-        "index": 790
-    },
-    {
-        "url": "https://github.com/XeXSolutions/unraid-stats",
-        "profile": "https://forums.unraid.net/profile/165045-xexsolutions/",
-        "title": "XeXSolutions' Repository",
-        "index": 791
-    },
-    {
-        "url": "https://github.com/xiaodoudou/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145775-xiaodoudou/",
-        "title": "Xiaodoudou's Repository",
-        "index": 792
-    },
-    {
-        "url": "https://github.com/xompage/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/262898-xompage/",
-        "title": "xompage's Repository",
-        "index": 793
-    },
-    {
-        "url": "https://github.com/xxBeanSproutxx/unraid-docling-ca",
-        "profile": "https://forums.unraid.net/profile/288925-bean_sprout/",
-        "title": "xxBeanSproutxx's Repository",
-        "index": 794
-    },
-    {
-        "url": "https://github.com/valaypatel/unraidapps",
-        "profile": "https://forums.unraid.net/profile/120399-yoda/",
-        "title": "Yoda's Repository",
-        "index": 795
-    },
-    {
-        "url": "https://github.com/cslemieux/unraid-plugin-templates",
-        "profile": "https://forums.unraid.net/profile/98934-zapbranagann/",
-        "title": "zapbranagann's Repository",
-        "index": 796
-    },
-    {
-        "url": "https://github.com/caddickzac/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/293796-zcaddick/",
-        "title": "zcaddick's Repository",
-        "index": 797
-    },
-    {
-        "url": "https://github.com/Zggis/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/118712-zggis/",
-        "title": "Zggis' Repository",
-        "index": 798
-    },
-    {
-        "url": "https://github.com/JZomDev/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/159615-zguilt/",
-        "title": "zguilt's Repository",
-        "index": 799
-    },
-    {
-        "url": "https://github.com/zhtengw/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/245393-zhtengw/",
-        "title": "zhtengw's Repository",
-        "index": 800
-    },
-    {
-        "url": "https://github.com/Zuerrex/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/234570-zuerrex/",
-        "title": "zuerrex's Repository",
-        "index": 801
-    },
-    {
-        "url": "https://github.com/zyphermonkey/docker-templates",
-        "profile": "https://forums.unraid.net/profile/67871-zyphermonkey/",
-        "title": "zyphermonkey's Repository",
-        "index": 802
-    }
+  {
+    "url": "https://github.com/7eventy7/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/279422-7eventy7/",
+    "bio": "Developer of open source tools that enhance the self-hosted ecosystem. I build software to fill the gaps I discover in my homelab, focusing on clean interfaces and practical functionality.",
+    "icon": "https://raw.githubusercontent.com/7eventy7/unraid-templates/main/7eventy7/images/avatar.png",
+    "DonateLink": "https://ko-fi.com/7eventy7",
+    "DonateText": "Donations are always appreciated!",
+    "title": "7eventy7's Repository",
+    "index": 0
+  },
+  {
+    "url": "https://github.com/A75G/docker-templates",
+    "profile": "https://forums.unraid.net/profile/92683-a75g/",
+    "bio": "Random guy making templates.",
+    "icon": "https://raw.githubusercontent.com/A75G/docker-templates/master/templates/icons/avatar.png",
+    "DonateLink": "https://buymeacoffee.com/a75g",
+    "DonateText": "If you appreciate my work, donations are greatly appreciated!",
+    "Forum": "https://forums.unraid.net/topic/89502-support-a75g-repo/",
+    "title": "A75G's Repository",
+    "index": 1
+  },
+  {
+    "url": "https://github.com/Abrechen2/docker-templates",
+    "profile": null,
+    "bio": "This repository hosts Unraid Community Apps templates for Abrechen2's self-hosted projects.\n\nCurrently published:\n\n- TravStats \u2014 self-hosted travel logbook for small households and groups (1\u201310 users). It's a logbook, not a live tracker \u2014 you record trips manually, scan a boarding pass, or import an email/PDF; flights now, cruises in v2, hotels and POI on the roadmap. Visualise routes on interactive 2D/3D maps, collect 58 achievements, scan boarding passes (QR/barcode/OCR), import bookings from email and PDF via an optional local Ollama LLM, automated backups with retention, optional WebDAV off-site sync, encrypted API-key storage.\n- travstats-db \u2014 the pre-configured PostgreSQL 15 + PostGIS 3.4 companion database TravStats expects. Ships with the database/user pair already aligned to the TravStats default DATABASE_URL \u2014 only the password needs filling in.\n\nInstall order: travstats-db first, then TravStats. Both containers reach each other through the Unraid host via host.docker.internal, so no custom Docker network is required.\n\nSupport: GitHub issues at https://github.com/Abrechen2/TravStats/issues or the Unraid support thread linked below. README and troubleshooting live in the repository homepage.",
+    "icon": "https://raw.githubusercontent.com/Abrechen2/docker-templates/main/icon.svg",
+    "DonateLink": "https://www.paypal.com/donate?hosted_button_id=HW9MPYVURCT42",
+    "DonateText": "Support TravStats development",
+    "Forum": "https://forums.unraid.net/topic/198320-support-travstats-self-hosted-flight-tracker/",
+    "WebPage": "https://github.com/Abrechen2/docker-templates",
+    "title": "Abrechen2's Repository",
+    "index": 2
+  },
+  {
+    "url": "https://github.com/ArabCoders/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/260951-ac-watchstate/",
+    "bio": "Docker Images Maintainer.",
+    "icon": "https://raw.githubusercontent.com/ArabCoders/unraid-templates/master/arabcoders/images/profile.png",
+    "DonateLink": "https://worldwish.org/",
+    "DonateText": "If you appreciate my work, then please consider donating to children charity.",
+    "title": "AC-WatchState's Repository",
+    "index": 3
+  },
+  {
+    "url": "https://github.com/acidrs03/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/125556-acidrs/",
+    "bio": "I love crafting custom game servers that feel like they were built just for you \u2014 from modded Minecraft in Unraid to whatever gaming rabbit hole I fall into next. Always open for requests.",
+    "icon": "https://avatars.githubusercontent.com/u/30998404?v=4",
+    "DonateLink": "https://ko-fi.com/acidrs",
+    "DonateText": "If you\u2019ve found something useful or just enjoy watching my experiments unfold, feel free to toss a coffee my way. I will probably spend it on more tinkering.",
+    "title": "Acidrs' Repository",
+    "index": 4
+  },
+  {
+    "url": "https://github.com/advplyr/docker-templates",
+    "profile": "https://forums.unraid.net/profile/128533-advplyr/",
+    "bio": "Just tinkering around for now.",
+    "icon": "https://github.com/advplyr/docker-templates/raw/master/advplyr_avatar.png",
+    "title": "advplyr's Repository",
+    "index": 5
+  },
+  {
+    "url": "https://github.com/Aerilym/docker-templates",
+    "profile": "https://forums.unraid.net/profile/158147-aerilym/",
+    "bio": "Creating Docker containers to solve my problems and hopefully other people's problems too.",
+    "icon": "https://raw.githubusercontent.com/aerilym/docker-templates/master/aerilym/images/avatar.jpg",
+    "DonateLink": "https://paypal.me/aerilym",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Aerilym's Repository",
+    "index": 6
+  },
+  {
+    "url": "https://github.com/agusalex/docker-templates",
+    "profile": "https://forums.unraid.net/profile/80800-agusalex",
+    "bio": "Creating Unraid Apps for fun",
+    "icon": "https://raw.githubusercontent.com/agusalex/docker-templates/master/agusalex/images/avatar.jpg",
+    "DonateLink": "https://www.paypal.me/AgustinAlexander",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "agusalex' Repository",
+    "index": 7
+  },
+  {
+    "url": "https://github.com/ahmadnassri/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/123283-ahmad/",
+    "bio": "Developer applications, tools and utilities for Unraid",
+    "icon": "https://github.com/ahmadnassri.png",
+    "DonateLink": "https://github.com/sponsors/ahmadnassri",
+    "DonateText": "Buy me a coffee",
+    "title": "Ahmad's Repository",
+    "index": 8
+  },
+  {
+    "url": "https://github.com/alex3305/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/149439-alex3305/",
+    "bio": "Docker expert creating easy-to-use container stacks.",
+    "icon": "https://avatars.githubusercontent.com/u/5155694?v=4.jpg",
+    "title": "alex3305's Repository",
+    "index": 9
+  },
+  {
+    "url": "https://github.com/alex-red/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/160581-alexred/",
+    "bio": "Curating, creating, and contemplating awesome, productive projects.",
+    "icon": "https://github.com/alex-red.png",
+    "DonateLink": "https://ko-fi.com/alexredcode",
+    "DonateText": "Constantly low on coffee =], would appreciate some more.",
+    "title": "AlexRed's Repository",
+    "index": 10
+  },
+  {
+    "url": "https://github.com/alexycodes/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/288438-alexycodes/",
+    "bio": "Software developer specializing in building web applications. Enthusiastic about all things technology, with a special mention for servers and self-hosting.",
+    "icon": "https://raw.githubusercontent.com/alexycodes/alexycodes/refs/heads/main/avatar.svg",
+    "title": "Alexy's Repository",
+    "index": 11
+  },
+  {
+    "url": "https://github.com/Aquillacomputingsystem/unraid-templetes",
+    "profile": "https://forums.unraid.net/profile/86880-alphacosmos/",
+    "bio": "Just creating containers that I need that the CA store doesnt have. Mainly focussing on Media Server, Home Automation and 3d printing/CNC/engineering containers.",
+    "icon": "https://raw.githubusercontent.com/Alphacosmos/unraid-templetes/main/Images/logo.png",
+    "DonateLink": "https://paypal.me/justinkurban",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Alphacosmos' Repository",
+    "index": 12
+  },
+  {
+    "url": "https://github.com/alturismo/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/70845-alturismo/",
+    "bio": "some small dockers related to Multimedia preferences.",
+    "icon": "https://avatars1.githubusercontent.com/u/8406490?s=460&u=99ac623b70da7467b0d6db3bbef771b5680542e2&v=4",
+    "title": "alturismo's Repository",
+    "index": 13
+  },
+  {
+    "url": "https://github.com/am385/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/122712-am385/",
+    "bio": "Unraid Docker Templates maintained by am385.",
+    "icon": "https://raw.githubusercontent.com/am385/unraid-docker-templates/master/am385/images/profile.png",
+    "title": "am385's Repository",
+    "index": 14
+  },
+  {
+    "url": "https://github.com/cross-seed/unraid-template",
+    "profile": "https://forums.unraid.net/profile/243161-ambipro/",
+    "bio": "cross-seed dev, deluge team member, and creator of retraktarr",
+    "icon": "https://i.imgur.com/2icY7tF.png",
+    "DonateLink": "https://tip.ary.dev",
+    "DonateText": "If you appreciate any of my work, please consider buying me a coffee.",
+    "WebPage": "https://git.ary.dev",
+    "title": "ambipro's Repository",
+    "index": 15
+  },
+  {
+    "url": "https://github.com/andaks/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/114400-andaks/",
+    "bio": "Creating docker containers templates that i use.",
+    "icon": "https://avatars.githubusercontent.com/u/5965423",
+    "DonateLink": "https://paypal.me/andakz",
+    "DonateText": "If you like my work please consider Donating.",
+    "Forum": "https://forums.unraid.net/topic/177991-support-andaks-docker-application",
+    "title": "andaks' Repository",
+    "index": 16
+  },
+  {
+    "url": "https://github.com/andrew207/splunk",
+    "profile": "https://forums.unraid.net/profile/77842-andrew207/",
+    "bio": "Containers focused on security. Where possible based on Alpine.",
+    "DonateLink": "https://www.paypal.me/atunnecliffe",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Andrew207's Repository",
+    "index": 17
+  },
+  {
+    "url": "https://github.com/clairekardas/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/269754-anna/",
+    "bio": "literally just a girl. and Unraid user. publishing docker containers that i use.",
+    "icon": "https://github.com/clairekardas/unraid-templates/blob/main/images/profile.png?raw=true",
+    "WebPage": "https://github.com/clairekardas",
+    "title": "anna's Repository",
+    "index": 18
+  },
+  {
+    "url": "https://github.com/apfaffman/docker-templates",
+    "profile": "https://forums.unraid.net/profile/223909-apfaffman/",
+    "bio": "Just trying to spread the Unraid love by creating useful images.",
+    "icon": "https://raw.githubusercontent.com/apfaffman/docker-templates/refs/heads/main/peanut.png",
+    "DonateLink": "https://www.reddit.com/r/ukraine/comments/s6g5un/want_to_support_ukraine_heres_a_list_of_charities",
+    "DonateText": "If you like this, please consider donating to the Ukrainian defense effort.",
+    "title": "apfaffman's Repository",
+    "index": 19
+  },
+  {
+    "url": "https://github.com/rommapp/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/279632-arcaneasada/",
+    "bio": "The team behind RomM, the beautiful, powerful, self-hosted rom manager.",
+    "icon": "https://raw.githubusercontent.com/rommapp/romm/master/.github/resources/isotipo.png",
+    "Forum": "https://github.com/rommapp/romm/issues",
+    "Discord": "https://discord.gg/P5HtHnhUDH",
+    "WebPage": "https://opencollective.com/romm",
+    "title": "arcanesada's Repository",
+    "index": 20
+  },
+  {
+    "url": "https://github.com/ArieDed/unraid-template",
+    "profile": "https://forums.unraid.net/profile/119153-arieded/",
+    "bio": "Repository with some templates for useful Docker containers from Dockerhub that I use myself.",
+    "icon": "https://raw.githubusercontent.com/ArieDed/unraid-template/master/img/avatar.jpg",
+    "DonateLink": "https://www.paypal.me/arieded",
+    "DonateText": "Buy me a coffee",
+    "title": "ArieDed's Repository",
+    "index": 21
+  },
+  {
+    "url": "https://github.com/av1155/houndarr-unraid-template",
+    "profile": "https://forums.unraid.net/profile/294737-av1155/",
+    "bio": "Andrea A. Venti Fuentes is an independent software and platform engineer focused on building practical, reliable self-hosted tools and infrastructure.",
+    "icon": "https://avatars.githubusercontent.com/u/117413846?v=4",
+    "WebPage": "https://andreaventi.com",
+    "title": "av1155's Repository",
+    "index": 22
+  },
+  {
+    "url": "https://github.com/TheAxelander/unraid_ca",
+    "profile": "https://forums.unraid.net/profile/117678-axelander/",
+    "bio": "Free time developer of apps mostly based on C# and on personal needs.",
+    "icon": "https://secure.gravatar.com/avatar/1297f1219f717dac0210118c93717ce9",
+    "title": "Axelander's Repository",
+    "index": 23
+  },
+  {
+    "url": "https://github.com/b3rrytech/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/11610-b3rrytech/",
+    "bio": "In the spirit of \"Value for value\" in the self-hosting community I will try to publish easy-to-use Docker templates of useful applications for others to enjoy.\n    All cred to the authors of these images, as I'm no developer myself. Please show your support to them!",
+    "icon": "https://raw.githubusercontent.com/b3rrytech/unraid-docker-templates/main/ca_profile/b3rrytech_avatar.png",
+    "Forum": "https://general-support-url",
+    "title": "b3rrytech's Repository",
+    "index": 24
+  },
+  {
+    "url": "https://github.com/b3rs3rk/gpustat-unraid",
+    "profile": "https://forums.unraid.net/profile/103683-b3rs3rk",
+    "bio": "Author of the GPUStat plugin, and not much else.  Learned to code using PHP, so my work should be suspect at best.",
+    "icon": "https://avatars2.githubusercontent.com/u/3584954?s=460&u=e047c1e6439bb6c4e138d8fe1d377f346e806b78",
+    "DonateLink": "http://www.whippingchildhoodcancer.org/get-involved.html",
+    "DonateText": "If you enjoy my work and want to donate, please make one to Whipping Childhood Cancer.  Thanks!",
+    "title": "b3rs3rk's Repository",
+    "index": 25
+  },
+  {
+    "url": "https://github.com/balloob/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/62499-balloob/",
+    "bio": "Founder Home Assistant",
+    "icon": "https://github.com/balloob.png",
+    "DonateLink": "https://github.com/sponsors/balloob/",
+    "DonateText": "Fund the development of Home Assistant",
+    "title": "Balloob's Repository",
+    "index": 26
+  },
+  {
+    "url": "https://github.com/Balya/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/166805-balya/",
+    "bio": "I'm trying to support the community and create configurations for those applications that are not yet in the catalog.",
+    "icon": "https://avatars.githubusercontent.com/u/3105824?v=4",
+    "DonateLink": "https://qiwi.com/n/BALYA",
+    "DonateText": "If you like my work please consider Donating.",
+    "Facebook": "https://www.facebook.com/alexander.balya/",
+    "Twitter": "https://twitter.com/Balya",
+    "Discord": "https://discord.com/users/7817",
+    "title": "Balya's Repository",
+    "index": 27
+  },
+  {
+    "url": "https://github.com/miketweaver/docker-templates",
+    "profile": "https://forums.unraid.net/profile/69309-bashninja/",
+    "bio": "Creating Docker containers for myself and sharing with the world. I base most of my images on the LinuxServer.io system.",
+    "icon": "https://raw.githubusercontent.com/miketweaver/docker-templates/master/bashninja/bashninja.png",
+    "Forum": "https://forums.unraid.net/topic/46664-support-bashninja-dockers-starbound-pritunl-demonsaw-etc/",
+    "title": "bashNinja's Repository",
+    "index": 28
+  },
+  {
+    "url": "https://github.com/greycubesgav/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119829-beastieg/",
+    "bio": "Docker applications for Unraid. Includes cryptomator-webdav",
+    "icon": "https://avatars.githubusercontent.com/u/3426859?v=4",
+    "title": "beastieg's Repository",
+    "index": 29
+  },
+  {
+    "url": "https://github.com/BGameiro2000/unraid-ca",
+    "profile": "https://forums.unraid.net/profile/110702-bgameiro/",
+    "bio": "Undergraduate Physicist Student and hobbyist self-hoster. Repository with some templates for applications that I use myself.",
+    "icon": "https://bgameiro.gitlab.io/cv/profile.jpeg",
+    "DonateLink": "https://bgameiro.me/page/donate",
+    "DonateText": "If you like my work please consider Donating.",
+    "Forum": "https://forums.unraid.net/topic/94979-trilium-docker/",
+    "WebPage": "https://bgameiro.me/",
+    "title": "BGameiro's Repository",
+    "index": 30
+  },
+  {
+    "url": "https://github.com/binhex/templates",
+    "profile": "https://forums.unraid.net/profile/11148-binhex/",
+    "bio": "Producing Docker Images with Arch Linux base OS, the main philosophy here is to produce Docker Images that are up to date with the latest stable release (no beta's where possible) to minimize any coding related issues.",
+    "icon": "https://raw.githubusercontent.com/binhex/templates/main/unraid/ca_profile.jpg",
+    "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MM5E27UX6AUU4",
+    "DonateText": "If you appreciate my work, then please consider buying me a beer :D",
+    "title": "Binhex's Repository",
+    "index": 31
+  },
+  {
+    "url": "https://github.com/bitcryptic-gw/unraid-templates",
+    "profile": null,
+    "bio": "Self-hosted AI infrastructure, crypto/DePIN, and Docker templates for Unraid. Building NanoClaw (AI agent platform), ckpool-solo (Bitcoin solo mining), and BitCryptic Compute (crypto-native AI inference). Based in Sydney, Australia.",
+    "icon": "https://raw.githubusercontent.com/bitcryptic-gw/unraid-templates/main/icon.png",
+    "Twitter": "https://twitter.com/BitCrypticGW",
+    "WebPage": "https://bitcryptic.com",
+    "title": "BitCryptic's 2nd Repository",
+    "index": 32
+  },
+  {
+    "url": "https://github.com/bjonness406/Docker-templates",
+    "profile": "https://forums.unraid.net/profile/68356-bjonness406/",
+    "bio": "Making some docker templates",
+    "Forum": "https://forums.unraid.net/topic/47092-support-bjonness406s-repo/",
+    "title": "Bjonness406's Repository",
+    "index": 33
+  },
+  {
+    "url": "https://github.com/BoKKeR/RSSTT-Unraid",
+    "profile": "https://forums.unraid.net/profile/94594-bokker",
+    "bio": "Full time developer publishing mostly my own creations.",
+    "icon": "https://raw.githubusercontent.com/BoKKeR/RSSTT-Unraid/master/images/avatar.jpeg",
+    "DonateLink": "https://www.buymeacoffee.com/bokker",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "BoKKeR's Repository",
+    "index": 34
+  },
+  {
+    "url": "https://github.com/brockbreacher/join-bot-unraid",
+    "profile": "https://forums.unraid.net/profile/171183-brockbreacher/",
+    "bio": "Just a dummy with internet access.",
+    "icon": "https://brbr.xyz/wp-content/uploads/2020/06/e227d6cd-704a-4227-a35c-cbb003c67d55.jpg",
+    "DonateLink": "https://brbr.xyz/donate",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "brockbreacher's Repository",
+    "index": 35
+  },
+  {
+    "url": "https://github.com/cleao01/UnraidDockerTemplates",
+    "profile": "https://forums.unraid.net/profile/123530-cab%C3%A9/",
+    "bio": "Developing for pleasure",
+    "icon": "https://avatars.githubusercontent.com/u/47321842?s=96&v=4",
+    "title": "Cab\u00e9's Repository",
+    "index": 36
+  },
+  {
+    "url": "https://github.com/carroarmato0/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169872-carroarmato0/",
+    "bio": "Open-Source Linux consultant and Unraid enthousiast.",
+    "icon": "https://avatars.githubusercontent.com/u/1828645?v=4",
+    "DonateLink": "https://github.com/sponsors/carroarmato0",
+    "DonateText": "If you find this usefull, feel free to send a small donation (Paypal, Ko_fi or Lightning).",
+    "WebPage": "https://github.com/carroarmato0",
+    "title": "carroarmato0's Repository",
+    "index": 37
+  },
+  {
+    "url": "https://github.com/ccmpbll/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/5869-ccmpbll/",
+    "bio": "Not a developer. Learning stuff and making things.",
+    "icon": "https://raw.githubusercontent.com/ccmpbll/unraid-docker-templates/main/images/avatar.png",
+    "title": "ccmpbll's Repository",
+    "index": 38
+  },
+  {
+    "url": "https://github.com/rufuswilson/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/130601-cedev/",
+    "bio": "Creating containers",
+    "icon": "https://avatars.githubusercontent.com/u/1152051?s=400&v=4",
+    "DonateLink": "https://paypal.me/cdevivier",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "cedev's Repository",
+    "index": 39
+  },
+  {
+    "url": "https://github.com/celsian/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/120837-celsian/",
+    "bio": "Developing small tools to make tedious tasks less difficult.",
+    "icon": "https://raw.githubusercontent.com/celsian/unraid_templates/refs/heads/main/images/avatar.png",
+    "title": "Celsian's Repository",
+    "index": 40
+  },
+  {
+    "url": "https://github.com/RafaelCenzano/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/171730-cenzar/",
+    "bio": "Hosting templates for applications I personally use and things others might find useful. I am also working on developing some self hosted free and open source programs myself.",
+    "icon": "https://raw.githubusercontent.com/RafaelCenzano/unraid-templates/refs/heads/main/avatar.jpeg",
+    "DonateLink": "https://github.com/sponsors/RafaelCenzano",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "cenzar's Repository",
+    "index": 41
+  },
+  {
+    "url": "https://github.com/BB-BenBridges/docker-templates",
+    "profile": "https://forums.unraid.net/profile/70291-cheesemarathon/",
+    "bio": "Making awesome applications easy to install on the best NAS software, Unraid.",
+    "icon": "https://avatars.githubusercontent.com/u/16329132?v=4",
+    "Forum": "https://forums.unraid.net/topic/54183-support-cheesemarathons-repo/",
+    "WebPage": "https://docs.squishedmooo.com",
+    "title": "cheesemarathon's Repository",
+    "index": 42
+  },
+  {
+    "url": "https://github.com/chodeus/unraid-plugins",
+    "profile": null,
+    "bio": "Maintainer of the FolderView3 Plugin for Unraid",
+    "icon": "https://raw.githubusercontent.com/chodeus/unraid-plugins/main/chodeus/servericon.png",
+    "Forum": "https://forums.unraid.net/profile/283711-chodeus/",
+    "title": "chodeus's Repository",
+    "index": 43
+  },
+  {
+    "url": "https://github.com/ChongZhiJie0216/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/114492-chongzhijie/",
+    "bio": "A novice programmer",
+    "icon": "https://i.imgur.com/SfBmYmw.png",
+    "title": "ChongZhiJie's Repository",
+    "index": 44
+  },
+  {
+    "url": "https://github.com/chrizzo84/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/135280-chrizzo/",
+    "bio": "One of many who would like to contribute to the Unraid community as well.",
+    "icon": "https://raw.githubusercontent.com/chrizzo84/unraid-templates/main/images/self/chrizzo84.jpg",
+    "DonateLink": "https://paypal.me/CGrugel",
+    "DonateText": "If you like my work, feel free to PayPal me a coffee.",
+    "title": "chrizzo's Repository",
+    "index": 45
+  },
+  {
+    "url": "https://github.com/Cirx08/Unraid",
+    "profile": "https://forums.unraid.net/profile/288718-cirx08/",
+    "bio": "Software developer by day, software developer by night...",
+    "icon": "https://raw.githubusercontent.com/Memtly/Memtly.Assets/master/Logos/Community/Memtly.png",
+    "DonateLink": "https://buymeacoffee.com/memtly",
+    "DonateText": "BuyMeACoffee",
+    "WebPage": "https://github.com/Memtly",
+    "title": "Cirx08's Repository",
+    "index": 46
+  },
+  {
+    "url": "https://github.com/giuseppe99barchetta/SuggestArr",
+    "profile": "https://forums.unraid.net/profile/281768-ciuse99/",
+    "bio": "The Official SuggestArr Repository",
+    "icon": "https://raw.githubusercontent.com/giuseppe99barchetta/SuggestArr/master/unraid/logo.png",
+    "DonateLink": "https://buymeacoffee.com/suggestarr",
+    "DonateText": "If you appreciate our work, please consider supporting us by buying us a coffee!",
+    "title": "ciuse99's Repository",
+    "index": 47
+  },
+  {
+    "url": "https://github.com/ck9393/fanctrlplus",
+    "profile": "https://forums.unraid.net/profile/242702-ckchong/",
+    "bio": "FanCtrl Plus author. Personal project for Unraid, developed from real-world needs.",
+    "icon": "https://raw.githubusercontent.com/ck9393/fanctrlplus/main/images/fanctrlplus.png",
+    "DonateLink": "https://www.paypal.com/paypalme/cck9393",
+    "DonateText": "If you like my work, please consider donating!",
+    "Forum": "https://forums.unraid.net/topic/191722-plugin-fancrtl-plus/",
+    "title": "ck9393's Repository",
+    "index": 48
+  },
+  {
+    "url": "https://github.com/cmccambridge/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/83181-cmccambridge/",
+    "bio": "Hello! I maintain a few containers that support my home automation projects. Hopefully they're valuable to you as well! Please let me know through their support threads and GitHub Issues if you encounter any problems. This is a side project for me, so I'm not immediately responsive, but I will try to get back to you and help sort things out if I can.",
+    "icon": "https://raw.githubusercontent.com/cmccambridge/unraid-templates/master/cmccambridge/avatar.jpg",
+    "title": "cmccambridge's Repository",
+    "index": 49
+  },
+  {
+    "url": "https://github.com/cmoro-deusto/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/284950-cmoro-gondor/",
+    "bio": "Just a grumpy sysadmin/developer.",
+    "icon": "https://avatars.githubusercontent.com/u/1205035?v=4",
+    "title": "cmoro-gondor's Repository",
+    "index": 50
+  },
+  {
+    "url": "https://github.com/Cobbert/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/129102-cobb/",
+    "bio": "I make templates for things I like as I find them.",
+    "icon": "https://raw.githubusercontent.com/Cobbert/unraid-templates/main/72e78935ce9e246e918fa9e8ebf2d1578044f4cf_full.jpg",
+    "DonateLink": "https://www.paypal.com/donate/?business=RSYPKTC78X566<no_recurring=0<currency_code=USD",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "cobb's Repository",
+    "index": 51
+  },
+  {
+    "url": "https://github.com/Collectathon/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/209526-collectathon/",
+    "bio": "Templates for projects I like that don't exist yet.",
+    "icon": "https://raw.githubusercontent.com/Collectathon/unraid-templates/main/icons/avatar.png",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=E34Z6V3XTDTVL",
+    "DonateText": "A cup of hot chocolate for making your day a bit easier.",
+    "title": "Collectathon's Repository",
+    "index": 52
+  },
+  {
+    "url": "https://github.com/CollinHeist/UnraidConfig",
+    "profile": "https://forums.unraid.net/profile/172758-collinheist/",
+    "bio": "Creator of the TitleCardMaker",
+    "icon": "https://avatars.githubusercontent.com/u/17693271",
+    "DonateLink": "https://www.buymeacoffee.com/CollinHeist",
+    "DonateText": "If you like my work please consider Donating. Thanks!",
+    "Reddit": "https://www.reddit.com/user/CollinHeist",
+    "Discord": "https://discord.gg/bJ3bHtw8wH",
+    "title": "CollinHeist's Repository",
+    "index": 53
+  },
+  {
+    "url": "https://github.com/Core-i99/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/151311-core-i99/",
+    "bio": "Creating and maintaining templates for Unraid Docker containers.",
+    "icon": "https://raw.githubusercontent.com/Core-i99/unraid-docker-templates/main/templates/icons/avatar.png",
+    "title": "Core-i99's Repository",
+    "index": 54
+  },
+  {
+    "url": "https://github.com/coreylane/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/146143-coreylane/",
+    "bio": "Cloud and DevOps guy contributing useful tools to the CA portfolio with a\n        focus on high-quality images, efficiency, and open-source projects.",
+    "icon": "https://raw.githubusercontent.com/coreylane/unraid-ca-templates/master/images/avatar.jpeg",
+    "title": "coreylane's Repository",
+    "index": 55
+  },
+  {
+    "url": "https://github.com/corgan2222/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/102466-corgan/",
+    "bio": "IoT-Project Engineer",
+    "icon": "https://raw.githubusercontent.com/corgan2222/unraid-templates/main/img/avatar.png",
+    "DonateLink": "https://paypal.me/StefanKnaak",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://github.com/corgan2222",
+    "title": "corgan's Repository",
+    "index": 56
+  },
+  {
+    "url": "https://github.com/CorneliousJD/Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/78194-corneliousjd/",
+    "bio": "I am mostly taking other developers containers and building Unraid templates for them. I prefer to do this with official containers sraight from the devs when possible!",
+    "icon": "https://raw.githubusercontent.com/CorneliousJD/Docker-Templates/master/icons/corneliousjd.png",
+    "DonateLink": "http://paypal.me/corneliousjd",
+    "DonateText": "Donate",
+    "WebPage": "http://corneliousjd.com",
+    "title": "CorneliousJD's Repository",
+    "index": 57
+  },
+  {
+    "url": "https://github.com/Joey291/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/99592-cornflake/",
+    "bio": "Just trying to do my part by adding useful Containers",
+    "icon": "https://github.com/Joey291/unraid-templates/raw/main/templates/profile.jpeg",
+    "title": "Cornflake's Repository",
+    "index": 58
+  },
+  {
+    "url": "https://github.com/ctrlaltd1337ed/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/84709-ctrlaltd1337/",
+    "bio": "I create Unraid templates for app developers that either don't use Unraid, or don't want to maintain them. If there are any issues with my templates, check out the forums for my support thread.",
+    "icon": "https://raw.githubusercontent.com/ctrlaltd1337ed/unraid-templates/refs/heads/main/avatar.png",
+    "Forum": "https://forums.unraid.net/topic/188012-support-ctrlaltd1337s-unraid-templates/",
+    "title": "ctrlaltd1337's Repository",
+    "index": 59
+  },
+  {
+    "url": "https://github.com/CtznSniiips/UnraidTemplates",
+    "profile": "https://forums.unraid.net/profile/98131-ctznsnips/",
+    "bio": "Personal project tinkerer",
+    "icon": "https://github.com/CtznSniiips.png",
+    "DonateLink": "https://paypal.me/CtznSniiips",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "CtznSnips' Repository",
+    "index": 60
+  },
+  {
+    "url": "https://github.com/Cyberschorsch/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/279951-cyberschorsch/",
+    "bio": "Creating docker templates for the awesome Unraid Community!",
+    "icon": "https://avatars.githubusercontent.com/u/273226?v=4",
+    "title": "Cyberschorsch's Repository",
+    "index": 61
+  },
+  {
+    "url": "https://github.com/AnimaI/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/126104-d0ooo/",
+    "bio": "Docker container templates for Bitcoin infrastructure on Unraid systems.",
+    "icon": "https://raw.githubusercontent.com/AnimaI/unraid-templates/master/ca_profile/avatar.jpg",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=8L2DNWLVUFNGJ",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "D0ooo's Repository",
+    "index": 62
+  },
+  {
+    "url": "https://github.com/d3vyce/unraid-template",
+    "profile": "https://forums.unraid.net/profile/99205-d3vyce/",
+    "bio": "Developer",
+    "icon": "https://avatars.githubusercontent.com/u/44915747?v=4",
+    "title": "d3vyce's Repository",
+    "index": 63
+  },
+  {
+    "url": "https://github.com/JakeShirley/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/101291-darknavi/",
+    "bio": "Casual Unraid user.",
+    "icon": "https://avatars.githubusercontent.com/jakeshirley",
+    "DonateLink": "https://paypal.me/darknavi",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "darknavi's Repository",
+    "index": 64
+  },
+  {
+    "url": "https://github.com/jordan-dalby/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/281718-data-jordan/",
+    "bio": "Creating containers for some useful apps I've made!",
+    "icon": "https://avatars.githubusercontent.com/u/49979347?v=4",
+    "DonateLink": "https://ko-fi.com/zalosath",
+    "DonateText": "Donations are not necessary, but are greatly appreciated.",
+    "title": "data-jordan's Repository",
+    "index": 65
+  },
+  {
+    "url": "https://github.com/furritos/docker-templates",
+    "profile": "https://forums.unraid.net/profile/149001-deadfeet/",
+    "bio": "Containerizing various applications onto the Unraid platform",
+    "icon": "https://raw.githubusercontent.com/furritos/docker-templates/master/furritos/images/furritos_512_button.png",
+    "title": "DeadFeet's Repository",
+    "index": 66
+  },
+  {
+    "url": "https://github.com/D3lta/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/281050-decrevi/",
+    "bio": "Just another random cat on the internet doing a bunch of secret cat stuff",
+    "icon": "https://github.com/D3lta.png",
+    "DonateLink": "https://github.com/sponsors/D3lta",
+    "DonateText": "Buy a coffee for D3lta",
+    "WebPage": "https://github.com/D3lta",
+    "title": "decrevi's Repository",
+    "index": 67
+  },
+  {
+    "url": "https://github.com/diamkil/docker-templates",
+    "profile": "https://forums.unraid.net/profile/114067-diamkil/",
+    "bio": "I create custom templates for docker hub images that are not on Unraid by bigger sources like binhex or linuxserver",
+    "icon": "https://raw.githubusercontent.com/diamkil/docker-templates/master/diamkil/images/diamkil.png",
+    "title": "diamkil's Repository",
+    "index": 68
+  },
+  {
+    "url": "https://github.com/DiamondPrecisionComputing/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/91956-biggiesize/",
+    "bio": "Just a guy with a computer writing code and helping others.",
+    "icon": "https://github.com/DiamondPrecisionComputing/unraid-templates/blob/main/Profile%20Picture%20reverted.jpg?raw=true",
+    "DonateLink": "https://paypal.me/DiamondPrecision",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Diamond Precision Computing's Repository",
+    "index": 69
+  },
+  {
+    "url": "https://github.com/digiblur/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/75995-digiblur/",
+    "bio": "Just some Random dude making docker container templates to save you a bunch of clicks and research.",
+    "icon": "https://raw.githubusercontent.com/digiblur/unraid-docker-templates/master/images/digiblur.png",
+    "DonateLink": "https://www.paypal.me/digiblurDIY",
+    "DonateText": "If you like my work please consider Donating.",
+    "Facebook": "https://facebook.digiblur.com",
+    "Twitter": "https://twitter.com/digiblur",
+    "Discord": "https://discord.digiblur.com",
+    "WebPage": "https://www.digiblur.com",
+    "title": "digiblur's Repository",
+    "index": 70
+  },
+  {
+    "url": "https://github.com/disbedan015/nadekobotv4-unraid",
+    "profile": "https://forums.unraid.net/profile/115097-disbedan015/",
+    "bio": "Created Docker image as I didn't see an updated one for an app and I may start doing that for other apps I use",
+    "icon": "https://github.com/disbedan015/NadekoBotv4-Docker/blob/master/DAB-500.png?raw=true",
+    "DonateLink": "https://nadekobot.readthedocs.io/en/v4/donate/",
+    "DonateText": "Donation link is for the origial other of the software",
+    "title": "disbedan015's Repository",
+    "index": 71
+  },
+  {
+    "url": "https://github.com/djismgaming/docker-templates",
+    "profile": "https://forums.unraid.net/profile/124577-djismgaming/",
+    "bio": "Helping other developers get their great applications published as an Unraid template. :D",
+    "icon": "https://raw.githubusercontent.com/djismgaming/docker-templates/main/djismGAMING/img/me.jpg",
+    "DonateLink": "https://ko-fi.com/djismgaming",
+    "DonateText": "If I helped you in some way, you could consider donating.",
+    "Twitter": "https://twitter.com/djismgaming",
+    "title": "djismgaming's Repository",
+    "index": 72
+  },
+  {
+    "url": "https://github.com/jlesage/docker-templates",
+    "profile": "https://forums.unraid.net/profile/73771-djoss/",
+    "bio": "Creator of many Docker containers for great applications.  All containers are developed with simplicity and easy of use in mind.  Being based on Alpine Linux, they are lightweight and contain only what is required to run the dockerized application.",
+    "icon": "https://github.com/jlesage.png",
+    "DonateLink": "https://paypal.me/JocelynLeSage/0usd",
+    "DonateText": "If you like my work please consider donating.",
+    "title": "Djoss' Repository",
+    "index": 73
+  },
+  {
+    "url": "https://github.com/dkeners/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/287661-dkeners/",
+    "bio": "Maintaining templates for services I enjoy using; hopefully you enjoy them too :)",
+    "icon": "https://github.com/dkeners/unraid-templates/blob/main/dkeners/images/pfp.jpg?raw=true",
+    "DonateLink": "https://dankenerson.com/donate",
+    "DonateText": "I\u2019m just copy-pasting XML files here. Please consider donating to the creators of the projects you love. If you still feel like sharing a little something after that, I wouldn't mind a cup o' tea! \ud83d\ude09",
+    "title": "dkeners' Repository",
+    "index": 74
+  },
+  {
+    "url": "https://github.com/dlandon/docker.templates",
+    "profile": "https://forums.unraid.net/profile/6013-dlandon/",
+    "bio": "Developer of the Unassigned Devices (UD) plugin for mounting disks and remote NFS/SMB shares for local access.  Disk devices can be hot plugged and scripts automatically run for backup purposes.  Encrypted disks are supported.\n\tCreator of the per share Recycle Bin for deleted files from SMB shares.\n\tAlso have several other utility plugins to help with tweaking and managing your Unraid server.",
+    "icon": "https://raw.githubusercontent.com/dlandon/docker.templates/master/avatar.png",
+    "DonateLink": "https://www.paypal.com/us/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=EJGPC7B5CS66E",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "dlandon's Repository",
+    "index": 75
+  },
+  {
+    "url": "https://github.com/yannisalexiou/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/283014-yannisalexiou/",
+    "bio": "iOS Tech Lead passionate about developer tooling and automation. \n    I create lightweight, production-ready Docker containers focused on developer workflows \u2014 like real-time App Store Connect webhook proxies for Slack and Microsoft Teams.\n    \n    All my containers follow a clear purpose: minimal, secure, and easy to integrate into CI/CD or self-hosted environments.",
+    "icon": "https://gravatar.com/avatar/c93735d1994346485c1593e5808d3750?size=256",
+    "DonateLink": "https://coff.ee/alexiou",
+    "DonateText": "If my work helps your workflow, consider supporting it \u2615",
+    "title": "Docked by Yannis' Repository",
+    "index": 76
+  },
+  {
+    "url": "https://github.com/Donimax/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/266669-donimax/",
+    "bio": "I am too lazy to find a profile description.",
+    "icon": "https://avatars.githubusercontent.com/u/35191173?v=4",
+    "WebPage": "https://github.com/Donimax",
+    "title": "Donimax's Repository",
+    "index": 77
+  },
+  {
+    "url": "https://github.com/donkevlar/Unraid-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/86041-donkevlar/",
+    "bio": "I like to fail at Python.",
+    "icon": "https://donkevlar.github.io/Unraid-Docker-Templates/images/avatar.png",
+    "Forum": "https://forums.unraid.net/profile/86041-donkevlar/",
+    "title": "DonKevlar's Repository",
+    "index": 78
+  },
+  {
+    "url": "https://github.com/dopeytree/Unraid-templates",
+    "profile": "https://forums.unraid.net/profile/183052-dopeytree/",
+    "bio": "Mostly my own apps. A tinkering open-source developer & fellow Unraid user. All that matters is that you are making something you love, to the best of your ability, here & now \u2764\ufe0f\u200d\ud83d\udd25",
+    "icon": "https://github.com/dopeytree.png",
+    "DonateLink": "https://github.com/sponsors/dopeytree",
+    "DonateText": "Support my projects",
+    "Forum": "https://forums.unraid.net/topic/194221-support-dopeytree-docker-templates/",
+    "WebPage": "https://ed-stone.co.uk",
+    "title": "dopeytree's Repository",
+    "index": 79
+  },
+  {
+    "url": "https://github.com/dorgan/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/78375-dorgan/",
+    "bio": "Creator/Maintainer of Network Stats plugin as well as Plex Streams plugin",
+    "icon": "https://raw.githubusercontent.com/dorgan/unraid-templates/master/images/avatar.jpg",
+    "DonateLink": "https://paypal.me/dorgan1983",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "dorgan's Repository",
+    "index": 80
+  },
+  {
+    "url": "https://github.com/catalinberta/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/258399-dracon/",
+    "bio": "Creating various (hopefully useful) containers and open source services.",
+    "icon": "https://catalinberta.com/files/me/avatar/300x300.jpg",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=42KHL5J2X3ASQ",
+    "DonateText": "If you like my work please consider Donating.",
+    "Discord": "https://eq6w.short.gy/discord-invite",
+    "title": "dracon's Repository",
+    "index": 81
+  },
+  {
+    "url": "https://github.com/deasmi/unraid-ca",
+    "profile": "https://forums.unraid.net/profile/73313-dsmith44/",
+    "bio": "I'm Dean and I occasionally fiddle with things like this.",
+    "icon": "https://en.gravatar.com/userimage/432758/d39e91adf4f2fa95de28d4a64610dc69.jpeg",
+    "DonateLink": "https://www.justgiving.com/fundraising/unraid-tailscale",
+    "DonateText": "If you like my work please consider donating to cancer research at https://www.justgiving.com/fundraising/unraid-tailscale.",
+    "title": "dsmith44's Repository",
+    "index": 82
+  },
+  {
+    "url": "https://github.com/dkaser/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/244077-edacerton/",
+    "bio": "Building solutions for problems I encounter.",
+    "icon": "https://raw.githubusercontent.com/dkaser/unraid-plugins/main/avatar.jpg",
+    "DonateLink": "https://github.com/sponsors/dkaser",
+    "DonateText": "If you like my work please consider donating.",
+    "title": "EDACerton's Repository",
+    "index": 83
+  },
+  {
+    "url": "https://github.com/eibex/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/268287-eibe/",
+    "bio": "A collection of Unraid templates for software that I created (often alongside amazing contributors) and maintain. I am a hobbyist, not a full-fledged developer.",
+    "icon": "https://avatars.githubusercontent.com/u/40539455?v=4",
+    "WebPage": "https://github.com/eibex",
+    "title": "Eibe's Repository",
+    "index": 84
+  },
+  {
+    "url": "https://github.com/EldonMcGuinness/UnraidCA",
+    "profile": "https://forums.unraid.net/profile/261788-eldonmcguinness/",
+    "bio": "Creating apps and the like to make life easier.",
+    "icon": "https://gravatar.com/userimage/133334237/5eb978c3eb400d3478a2eb9d8fa899be.jpeg?size=256",
+    "DonateLink": "https://www.paypal.me/progressivethinkin",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "EldonMcGuiness' Repository",
+    "index": 85
+  },
+  {
+    "url": "https://github.com/EMP83/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/271480-emp83/",
+    "bio": "EMP83, making some template to help.",
+    "icon": "https://raw.githubusercontent.com/EMP83/unraid-templates/main/images/Crysis.jpg",
+    "DonateLink": "https://ko-fi.com/emp83",
+    "DonateText": "Don't donate to me! Instead, please donate the creators of the apps, but if you insist.",
+    "title": "emp83's Repository",
+    "index": 86
+  },
+  {
+    "url": "https://github.com/ep1cman/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/69221-ep1cman/",
+    "bio": "Blue haired, maker, hacker and engineer.",
+    "icon": "https://avatars.githubusercontent.com/u/5303409",
+    "DonateLink": "https://www.buymeacoffee.com/ep1cman/",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://github.com/ep1cman",
+    "title": "ep1cman's Repository",
+    "index": 87
+  },
+  {
+    "url": "https://github.com/error311/UNRAID_COMMUNITY_APPS",
+    "profile": "https://forums.unraid.net/profile/207982-error311/",
+    "bio": "Creating web apps and tools for automation. Always trying to learn new things and improve.",
+    "icon": "https://github.com/error311/multi-file-upload-editor-docker/blob/2230ec266f24384b3b3ea73de2b78dad1549a7ab/I_am_Error.png?raw=true",
+    "title": "error311's Repository",
+    "index": 88
+  },
+  {
+    "url": "https://github.com/Eurotimmy/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/175441-eurotimmy/",
+    "bio": "Giving something back to the Unraid community... I think.",
+    "icon": "https://raw.githubusercontent.com/Eurotimmy/unraid-templates/main/bubble.png",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=NU5FVN8NDE4S8",
+    "DonateText": "I make the templates; you make the magic. If this was useful, shout me a coffee?\u2615",
+    "title": "Eurotimmy's Repository",
+    "index": 89
+  },
+  {
+    "url": "https://github.com/ItJustFox/unraidtemplate",
+    "profile": "https://forums.unraid.net/profile/142238-fantucie/",
+    "bio": "Hello, I am Fantucie, also know has ItJustFox ! I am a french developper using Java JScript and Json, making mods/3DModels for Minecraft principally. Mostly fan of Sinon from GGO, I can be a bit shy, but i promise that one day, we will talk together !",
+    "icon": "https://avatars.githubusercontent.com/u/42358087?v=4",
+    "title": "Fantucie's Repository",
+    "index": 90
+  },
+  {
+    "url": "https://github.com/avpnusr/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/126700-fatzcat/",
+    "bio": "Docker container creator, full-time engineer and openminded geek. That's all ...",
+    "icon": "https://github.com/avpnusr/unraid-ca-templates/raw/master/img/profile.png",
+    "title": "FatzCat's Repository",
+    "index": 91
+  },
+  {
+    "url": "https://github.com/feederbox826/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/281190-feederbox826/",
+    "bio": "Community developer focused on extending stashapp/stash",
+    "icon": "https://feederbox.cc/profile.jpg",
+    "DonateLink": "https://opencollective.com/stashapp",
+    "DonateText": "Sustain the continued development of stash",
+    "WebPage": "https://feederbox.cc",
+    "title": "feederbox826's Repository",
+    "index": 92
+  },
+  {
+    "url": "https://github.com/AriaGomes/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/107309-figro/",
+    "bio": "Junior Developer that likes to mess around with dockers in his spare time",
+    "icon": "https://raw.githubusercontent.com/AriaGomes/Unraid-Templates/master/Images/profile.png",
+    "DonateLink": "https://www.buymeacoffee.com/ariagomes",
+    "DonateText": "Buy me a coffee :)",
+    "title": "Figro's Repository",
+    "index": 93
+  },
+  {
+    "url": "https://github.com/fileflows/FileFlowsUnraid",
+    "profile": "https://forums.unraid.net/profile/1117-reven/",
+    "bio": "Developer of FileFlows",
+    "icon": "https://avatars.githubusercontent.com/u/958400",
+    "DonateLink": "https://www.patreon.com/revenz",
+    "DonateText": "If you like my work please consider Donating.",
+    "Discord": "https://discord.gg/xbYK8wFMeU",
+    "WebPage": "https://fileflows.com/",
+    "title": "fileflows's Repository",
+    "index": 94
+  },
+  {
+    "url": "https://github.com/findthelorax/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169140-findthelorax/",
+    "bio": "Full Stack Developer with a passion for technology and a love for Open Source. I am always looking for ways to improve my skills and learn new things. I am a huge fan of Unraid and the community that surrounds it.",
+    "icon": "https://avatars.githubusercontent.com/u/83841899?v=4",
+    "DonateLink": "https://buymeacoffee.com/findthelorax",
+    "DonateText": "If you like my work please consider donating.",
+    "title": "Findthelorax's Repository",
+    "index": 95
+  },
+  {
+    "url": "https://github.com/fithwum/files-for-dockers",
+    "profile": "https://forums.unraid.net/profile/82177-fithwum/",
+    "bio": "I have made a few dockers now.  \n    Might make others when or if they might be needed.",
+    "icon": "https://gitea.fithwum.tech/fithwum/files-for-dockers/raw/branch/master/icons/fithwum.png",
+    "DonateLink": "https://checkout.square.site/pay/340d93c602a042b8a223a2f7c184a6a2",
+    "DonateText": "Buy me a coffee if you like.",
+    "WebPage": "https://hoots.fithwum.tech",
+    "title": "fithwum's Repository",
+    "index": 96
+  },
+  {
+    "url": "https://github.com/Cleanuparr/unraid",
+    "profile": "https://forums.unraid.net/profile/282380-flamin/",
+    "bio": "Creating software to make my life easier and to learn.",
+    "icon": "https://raw.githubusercontent.com/flmorg/unraid/main/templates/img/tom.jpg",
+    "DonateLink": "https://buymeacoffee.com/flaminel",
+    "DonateText": "If I made your life just a tiny bit easier, consider buying me a coffee!",
+    "title": "Flamin's Repository",
+    "index": 97
+  },
+  {
+    "url": "https://github.com/olehj/unraid",
+    "profile": "hhttps://forums.unraid.net/profile/86216-flamongole/",
+    "bio": "Creator of Disk Location plugin for Unraid.",
+    "icon": "https://raw.githubusercontent.com/olehj/unraid/master/flamongo.png",
+    "DonateLink": "https://www.paypal.me/olehj",
+    "DonateText": "Feel free to donate me a beer if you like my plugin!",
+    "Forum": "https://forums.unraid.net/profile/86216-olehj/",
+    "title": "FlamongOle's Repository",
+    "index": 98
+  },
+  {
+    "url": "https://github.com/nzzane/nzzane-unraid-repo",
+    "profile": "https://forums.unraid.net/profile/113405-flippinturt/",
+    "bio": "Just here to help the community out and make fun things ;)",
+    "icon": "https://raw.githubusercontent.com/nzzane/nzzane-unraid-repo/main/Icons/zrh_profile.jpg",
+    "DonateLink": "https://www.paypal.com/donate?hosted_button_id=4CL2REKSGRLWA",
+    "DonateText": "If you appreciate my work, then please consider buying me a Snacc :D",
+    "WebPage": "https://turtledev.nz",
+    "title": "FlippinTurt's Repository",
+    "index": 99
+  },
+  {
+    "url": "https://github.com/manyfold3d/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/277882-floppyuk/",
+    "bio": "Building a self-hosted 3d model organisation app for 3d printing enthusiasts",
+    "icon": "https://manyfold.app/images/logo.png",
+    "DonateLink": "https://opencollective.com/manyfold",
+    "DonateText": "Help us make Manyfold even better!",
+    "WebPage": "https://manyfold.app",
+    "title": "FloppyUK's Repository",
+    "index": 100
+  },
+  {
+    "url": "https://github.com/Lowess/docker-templates-unraid",
+    "profile": "https://forums.unraid.net/profile/161755-florian-dambrine/",
+    "bio": "Passionate DevOps engineer crafting Docker containers with a unique twist. My approach goes\n        beyond conventional methods, focusing on lean containers with only essential dependencies.\n        Each container dynamically fetches and updates the application upon start/restart, ensuring\n        seamless operation. Join me in redefining the Unraid experience, one container at a time.",
+    "icon": "https://raw.githubusercontent.com/Lowess/docker-templates-unraid/main/Lowess/images/avatar.png",
+    "title": "Florian Dambrine's Repository",
+    "index": 101
+  },
+  {
+    "url": "https://github.com/framedr0p/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/290788-framedr0p/",
+    "bio": "I'm new so be kind :-D",
+    "icon": "https://github.com/framedr0p/unraid-templates/blob/master/avatar.jpeg",
+    "DonateLink": "https://paypal.me/mex990",
+    "DonateText": "If you appreciate my work, then please consider buying me a drink :D",
+    "title": "framdr0p's Repository",
+    "index": 102
+  },
+  {
+    "url": "https://github.com/Frooodle/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/128782-froodle/",
+    "bio": "Hopefully working on more CICD related things in future, maybe also plex related things. Feel free to PM me for help.",
+    "icon": "https://raw.githubusercontent.com/Frooodle/unraid-templates/main/logos/Froodle.png",
+    "DonateLink": "https://www.paypal.com/paypalme/FroodlePlex",
+    "DonateText": "You shouldn't donate, I have not made these docker images only did some config.. \n  But if you really want to, thanks :)",
+    "title": "Froodle's Repository",
+    "index": 103
+  },
+  {
+    "url": "https://github.com/connorgallopo/tracearr-unraid-template",
+    "profile": "https://forums.unraid.net/profile/281348-gallapagos/",
+    "bio": "Tech Leader, Software Engineer, and Open Source maintainer. Creator of Tracearr.",
+    "icon": "https://avatars.githubusercontent.com/u/21372032",
+    "DonateLink": "https://github.com/sponsors/connorgallopo",
+    "DonateText": "If you like my work, please consider sponsoring me on GitHub",
+    "Discord": "https://discord.gg/a7n3sFd2Yw",
+    "WebPage": "https://tracearr.com",
+    "title": "Gallapagos' Repository",
+    "index": 104
+  },
+  {
+    "url": "https://github.com/GeiserX/docker-templates",
+    "profile": "https://forums.unraid.net/profile/276896-geiserx/",
+    "bio": "Self-hosted Docker images for networking, media management, backups, and productivity. Multi-arch (amd64/arm64) wherever possible.",
+    "icon": "https://github.com/GeiserX.png",
+    "WebPage": "https://geiser.cloud",
+    "title": "geiserx's Repository",
+    "index": 105
+  },
+  {
+    "url": "https://github.com/giganode/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/105464-giganode/",
+    "bio": "I'm just beginning.",
+    "icon": "https://raw.githubusercontent.com/giganode/unraid-plugins/main/avatar.jpg",
+    "DonateLink": "https://paypal.me/MReimer5592",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "giganode's Repository",
+    "index": 106
+  },
+  {
+    "url": "https://github.com/GlassedSilver/unRAID-CAs",
+    "profile": "https://forums.unraid.net/profile/91241-glassed-silver",
+    "bio": "Unraid Community Applications I created because I didn't find them.\n    I create these for personal use and share them for anyone else to enjoy.\n    \n    I provide support for them over at the Unraid Forums, where each CA gets its own thread, because reading or asking in a thread that's a lump of 10 containers is convoluted.\n    \n    Please keep in mind that whilst I will support setting these up for your scenario to the best of my abilities, I cannot provide the same level of support for the applications themselves, especially if you encountered a bug. If you do, I strongly recommend you go to the official bug tracker/other support outlet.",
+    "icon": "https://avatars.githubusercontent.com/u/1912133",
+    "Forum": "https://forums.unraid.net/profile/91241-glassed-silver/",
+    "Twitter": "https://twitter.com/GlassedSilver",
+    "title": "Glassed Silver's Repository",
+    "index": 107
+  },
+  {
+    "url": "https://github.com/glls/Docker-Templates-Unraid",
+    "profile": "https://forums.unraid.net/profile/272335-glls/",
+    "bio": "Software Engineer | Docker templates for Unraid. Retro enthusiast / Open Source supporter. Learn more on my page.",
+    "icon": "https://avatars.githubusercontent.com/u/392030?v=4",
+    "DonateLink": "https://www.paypal.me/GeorgeLitos",
+    "DonateText": "If you like my work please consider donating.",
+    "Forum": "https://forums.unraid.net/profile/272335-glls/",
+    "WebPage": "https://georgelitos.com/",
+    "title": "glls' Repository",
+    "index": 108
+  },
+  {
+    "url": "https://github.com/Goobaroo/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/113292-goobaroo/",
+    "bio": "I like to publish things I create for myself.  Right now creating modded minecrafte server containers. Let me know if you have any requests.",
+    "icon": "https://raw.githubusercontent.com/Goobaroo/unraid-templates/main/goobaroo.png",
+    "DonateLink": "https://ko-fi.com/goobaroo",
+    "DonateText": "If you like my work, you can buy me a coffee. But not at all expected.",
+    "title": "Goobaroo's Repository",
+    "index": 109
+  },
+  {
+    "url": "https://github.com/RichKidsDev/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/156616-grafgenixs/",
+    "bio": "I enjoy creating templates for Community Applications in Unraid to make it easier for users to install Docker containers. This is a passion project for me, and I love contributing to the Unraid community by simplifying the process and sharing my work.",
+    "icon": "https://github.com/RichKidsDev/Unraid-Templates/blob/main/logo-grafgenixs.png?raw=true",
+    "title": "GrafGenixs' Repository",
+    "index": 110
+  },
+  {
+    "url": "https://github.com/Greite/unraid-templates",
+    "profile": null,
+    "bio": "GreiteTurtle's Unraid templates. Source-available under the MIT license. Bug reports and pull requests welcome on GitHub.",
+    "icon": "https://github.com/Greite.png",
+    "WebPage": "https://github.com/Greite/unraid-templates",
+    "title": "GreiteTurtle",
+    "index": 111
+  },
+  {
+    "url": "https://github.com/nwithan8/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/81372-grtgbln/",
+    "bio": "An open-source developer and fellow Unraid user, creating and maintaining templates for the community. Some templates are for my own projects, but I'm happy to add any template that is requested.",
+    "icon": "https://codeberg.org/nwithan8/assets/raw/branch/main/images/avatar/goblin/goblin_300.png",
+    "DonateLink": "https://www.buymeacoffee.com/nwithan8",
+    "DonateText": "If you like an app, please donate to the respective developers; I'm just writing XML files over here. But if you have some change to spare afterwards, maybe chuck me a buck?",
+    "Forum": "https://forums.unraid.net/topic/133764-support-grtgbln-docker-templates",
+    "WebPage": "https://github.com/nwithan8/unraid_templates",
+    "title": "grtgbln's Repository",
+    "index": 112
+  },
+  {
+    "url": "https://github.com/gthrift/gthrift-unraid-ca",
+    "profile": "https://forums.unraid.net/profile/293215-gthrift/",
+    "bio": "Building apps that I want to use for myself and sharing with the community.",
+    "title": "gthrift's Repository",
+    "index": 113
+  },
+  {
+    "url": "https://github.com/soerentsch/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/146285-gucky79/",
+    "bio": "Don't PANIC! And carry a towel. Searching Milk and Kahlua for the Dude. Earl grey, hot! And the rest of my time i'm a Developer and Maker with passion ;-)",
+    "icon": "https://avatars.githubusercontent.com/u/5426009?v=4",
+    "DonateLink": "https://paypal.me/SoerenSchwirsch",
+    "DonateText": "Help support my work by buying me a beer",
+    "title": "gucky79's Repository",
+    "index": 114
+  },
+  {
+    "url": "https://github.com/GuildDarts/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/80260-guilddarts/",
+    "bio": "Having fun playing with my Unraid server ^_^",
+    "icon": "https://raw.githubusercontent.com/GuildDarts/unraid-ca-templates/master/avatar.png",
+    "title": "GuildDart's Repository",
+    "index": 115
+  },
+  {
+    "url": "https://github.com/guniv/unraid-ca-apps",
+    "profile": "https://forums.unraid.net/profile/178712-guniv/",
+    "bio": "Guy who barely knows what he is doing",
+    "icon": "https://raw.githubusercontent.com/guniv/unraid-ca-apps/master/pic/pic.jpg",
+    "Reddit": "https://www.reddit.com/user/guniv/",
+    "title": "guniv's Repository",
+    "index": 116
+  },
+  {
+    "url": "https://github.com/kylejschultz/unraid-templates",
+    "profile": null,
+    "bio": "Homelab tinkerer. Building open-source tools for self-hosters.",
+    "icon": "https://raw.githubusercontent.com/kylejschultz/unraid-templates/main/nestview/nestview-icon.png",
+    "Discord": "https://discord.gg/TfQ8QX3Ptr",
+    "title": "Gurthyy's Repository",
+    "index": 117
+  },
+  {
+    "url": "https://github.com/guydavis/machinaris-unraid",
+    "profile": "https://forums.unraid.net/profile/126090-guydavis/",
+    "bio": "Unraid enthusiast and Chia (+forks) farmer.",
+    "icon": "https://raw.githubusercontent.com/guydavis/machinaris-unraid/master/guy_davis.png",
+    "Discord": "https://discord.gg/mX4AtMTt87",
+    "WebPage": "https://github.com/guydavis",
+    "title": "guy.davis' Repository",
+    "index": 118
+  },
+  {
+    "url": "https://github.com/bpivk/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/67984-gxs/",
+    "bio": "I create Unraid docker templates for containers I find interesting and/or useful.",
+    "icon": "https://raw.githubusercontent.com/bpivk/unraid-templates/main/images/ca_profile.jpg",
+    "DonateLink": "https://www.paypal.com/paypalme/bpivk",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "gxs' Repository",
+    "index": 119
+  },
+  {
+    "url": "https://github.com/UnknownHiker/unraid-template-kitchenowl",
+    "profile": "https://forums.unraid.net/profile/155012-hansolo97/",
+    "bio": "Doing my best to help filling the gap of services, that dont have a Unraid Template yet. :-)",
+    "icon": "https://codeberg.org/avatars/2cdf72f6241e5b528099558d665454310cf0373b9efe47f03f614ef6b04b23b2?size=512",
+    "WebPage": "https://codeberg.org/HanSolo97",
+    "title": "HanSolo97's Repository",
+    "index": 120
+  },
+  {
+    "url": "https://github.com/prolife86/unraid-templates",
+    "profile": null,
+    "bio": "A self-hosting enthusiast and whisky lover who builds the tools he actually wants to use. From a full-featured web vault for your spirits collection to a native Android companion, that keeps your data where it belongs \u2014 at home.",
+    "icon": "https://raw.githubusercontent.com/prolife86/WhiskyWise/refs/heads/main/Icons/Icon%201.png",
+    "DonateLink": "https://www.paypal.me/SonsyICT",
+    "DonateText": "Help support my work by buying me a coffee",
+    "title": "Heisenbugger's Repository",
+    "index": 121
+  },
+  {
+    "url": "https://github.com/hhftechnology/unraid_app_templates",
+    "profile": "https://forums.unraid.net/profile/282959-hhftechnology/",
+    "bio": "Just another Infrastructure Engineer and Homelab Enthusiast.",
+    "icon": "https://raw.githubusercontent.com/hhftechnology/unraid_app_templates/refs/heads/main/images/hhflogo.png",
+    "title": "hhftechnology's Repository",
+    "index": 122
+  },
+  {
+    "url": "https://github.com/hotio/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/94356-hotio",
+    "bio": "I maintain a few docker images (Ubuntu or Alpine based) and try to deliver incredibly fast updates, all automated and tested before pushing them into the world.",
+    "icon": "https://hotio.dev/webhook-avatars/hotio.png",
+    "DonateLink": "https://hotio.dev/donate",
+    "DonateText": "You can become a GitHub sponsor, use Open Collective or send some Crypto...Affiliate links for VPN providers are on the website.",
+    "Discord": "https://hotio.dev/discord",
+    "WebPage": "https://hotio.dev",
+    "title": "hotio's Repository",
+    "index": 123
+  },
+  {
+    "url": "https://github.com/hsiang-han/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/213571-hsiang/",
+    "bio": "Just some Unraid apps I use and maintain.",
+    "icon": "https://raw.githubusercontent.com/hsiang-han/unraid_templates/main/assets/avatar.png",
+    "DonateLink": "https://github.com/sponsors/hsiang-han",
+    "DonateText": "Like these apps? Support me on GitHub Sponsors.",
+    "title": "hsiang's Repository",
+    "index": 124
+  },
+  {
+    "url": "https://github.com/hudikhq/hoodik-unraid",
+    "profile": "https://forums.unraid.net/profile/228687-htunlogic/",
+    "bio": "Creating applications and containers for myself and sharing them with you with \u2764\ufe0f",
+    "icon": "https://raw.githubusercontent.com/hudikhq/hoodik-unraid/main/images/avatar.jpeg",
+    "DonateLink": "https://paypal.me/htunlogic",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "htunlogic's Repository",
+    "index": 125
+  },
+  {
+    "url": "https://github.com/ibracorp/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/106623-sycotix/",
+    "bio": "We are IBRACORP. We create Docker templates, Guides and YouTube videos to get your homelab set up across a range of needs, from basic all the way to enterprise level. Join our Discord!",
+    "icon": "https://raw.githubusercontent.com/ibracorp/unraid-templates/master/V3Icon.png",
+    "DonateLink": "https://paypal.me/ibracorp",
+    "DonateText": "If you like our work please consider Donating.",
+    "Discord": "https://discord.gg/VWAG7rZ",
+    "WebPage": "https://ibracorp.io",
+    "title": "IBRACORP's Repository",
+    "index": 126
+  },
+  {
+    "url": "https://github.com/ich777/docker-templates",
+    "profile": "https://forums.unraid.net/profile/72388-ich777/",
+    "bio": "Creating Containers and Plugins with the intention to make them as easy as possible to install and use.",
+    "icon": "https://raw.githubusercontent.com/ich777/docker-templates/master/ich777/images/avatar.jpg",
+    "DonateLink": "https://www.paypal.me/chips777",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "ich777's Repository",
+    "index": 127
+  },
+  {
+    "url": "https://github.com/IkerSaint/ZFS-Master-Unraid",
+    "profile": "https://forums.unraid.net/profile/102954-iker/",
+    "bio": "Information Security, Tech Enthusiast, Data Enthusiast, Amateur Developer",
+    "icon": "https://avatars.githubusercontent.com/u/18542097",
+    "DonateLink": "https://www.paypal.com/paypalme/ikersaint",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://ikersaint.medium.com",
+    "title": "Iker's Repository",
+    "index": 128
+  },
+  {
+    "url": "https://github.com/RealFascinated/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/87787-imfascinated/",
+    "bio": "Creating simple and useful Docker containers for users of Unraid and much more!",
+    "icon": "https://git.fascinated.cc/Fascinated/unraid-templates/raw/branch/master/images/profile_picture.webp",
+    "Discord": "https://discord.gg/yjj2U3ctEG",
+    "title": "ImFascinated's Repository",
+    "index": 129
+  },
+  {
+    "url": "https://github.com/ImSkully/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/186901-imskully/",
+    "bio": "Maintaining container templates for community applications, one image at a time.",
+    "icon": "https://github.com/ImSkully.png",
+    "DonateLink": "https://buymeacoffee.com/skully",
+    "DonateText": "If you use any of the applications that I maintain, feel free to support my work by buying me a coffee!",
+    "Discord": "https://skully.tech/discord",
+    "WebPage": "https://skully.tech",
+    "title": "ImSkully's Repository",
+    "index": 130
+  },
+  {
+    "url": "https://github.com/imthenachoman/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/134093-imthenachoman/",
+    "bio": "Nobody special. Just doing this for fun.",
+    "icon": "https://avatars.githubusercontent.com/u/83817?s=400&u=0ce202f0f0cd5d1a653cf86ebec583211f614a73&v=4",
+    "DonateLink": "https://paypal.me/imthenachoman?country.x=US&locale.x=en_US",
+    "DonateText": "If you like my work please consider Donating.",
+    "Reddit": "https://www.reddit.com/user/imthenachoman/",
+    "Twitter": "http://twitter.com/imthenachoman",
+    "WebPage": "https://www.nigam.dev/",
+    "title": "IMTheNachoMan's Repository",
+    "index": 131
+  },
+  {
+    "url": "https://github.com/J000K3R/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/127281-j000k3r/",
+    "bio": "simple Unraid templates",
+    "icon": "https://raw.githubusercontent.com/J000K3R/unraid-templates/refs/heads/main/Images/Joker.jpg",
+    "title": "J000K3R's Repository",
+    "index": 132
+  },
+  {
+    "url": "https://github.com/j1philli/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/84279-j1philli/",
+    "bio": "Amateur developer bringing the tools I use to Unraid.",
+    "icon": "https://avatars.githubusercontent.com/u/3744255?v=4",
+    "Twitter": "https://twitter.com/j1philli",
+    "title": "j1philli's Repository",
+    "index": 133
+  },
+  {
+    "url": "https://github.com/JasonPuglisi/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294612-jasonpuglisi/",
+    "bio": "Hacker, musician, artist, explorer",
+    "icon": "https://avatars.githubusercontent.com/u/5090549",
+    "WebPage": "https://pugli.si",
+    "title": "JasonPuglisi's Repository",
+    "index": 134
+  },
+  {
+    "url": "https://github.com/jbrodriguez/unraid",
+    "profile": "https://forums.unraid.net/profile/593-jbrodriguez/",
+    "bio": "Creator and maintainer of unbalanced and ControlR, specifically developed for Unraid.",
+    "icon": "https://raw.githubusercontent.com/jbrodriguez/unraid/main/jb.png",
+    "DonateLink": "https://jbrio.net/unbalanced",
+    "DonateText": "If you like my work please consider sponsoring.",
+    "title": "jbrodriguez's Repository",
+    "index": 135
+  },
+  {
+    "url": "https://github.com/jcofer555/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/135547-jcofer555/",
+    "bio": "Hi, I'm jcofer555 - I'm a software tech support kind of guy from the United States.\n    I like to provide help and tools to myself and others. For awhile now I have been a\n    discord moderator for the UnraidOfficial discord helping manage things there.\n    Love to collaborate and help others!",
+    "icon": "https://raw.githubusercontent.com/jcofer555/unraid-plugins/main/avatar.jpg",
+    "WebPage": "https://jcofer555.github.io/unraid-projects/",
+    "title": "jcofer555's Repository",
+    "index": 136
+  },
+  {
+    "url": "https://github.com/JeremiahChurch/arc-relay-unraid",
+    "profile": null,
+    "bio": "https://github.com/JeremiahChurch",
+    "icon": "https://raw.githubusercontent.com/JeremiahChurch/arc-relay-unraid/main/images/arc-relay-icon.png",
+    "title": "Jeremiah's Repository",
+    "index": 137
+  },
+  {
+    "url": "https://github.com/AMJidovu/unraid-repository",
+    "profile": "https://forums.unraid.net/profile/86478-jidovu-marius-adrian/",
+    "bio": "I love Unraid and creating Docker containers is one of my hobbies.",
+    "icon": "https://raw.githubusercontent.com/AMJidovu/unraid-repository/master/img/avatar.jpg",
+    "DonateLink": "https://www.paypal.me/xternet",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Jidovu Marius Adrian's Repository",
+    "index": 138
+  },
+  {
+    "url": "https://github.com/dannymate/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/87501-jimrummy101/",
+    "bio": "FOSS and Self-Hosting fan hoping to bring interesting applications to Unraid.",
+    "icon": "https://raw.githubusercontent.com/dannymate/unraid-templates/master/icons/avatar.png",
+    "Twitter": "https://twitter.com/slumbering_cat",
+    "WebPage": "https://github.com/dannymate",
+    "title": "jimrummy101's Repository",
+    "index": 139
+  },
+  {
+    "url": "https://github.com/juusujanar/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/79768-jj9987/",
+    "bio": "Bringing the containers to the users.",
+    "icon": "https://github.com/juusujanar.png",
+    "DonateLink": "https://www.paypal.me/jj9987",
+    "DonateText": "If you like my work and want to buy me a beer, feel free.",
+    "title": "jj9987's Repository",
+    "index": 140
+  },
+  {
+    "url": "https://github.com/jjdenhertog/spotify-to-plex-unraid",
+    "profile": "https://forums.unraid.net/profile/283509-jjdenhertog/",
+    "bio": "Loving music and home automation. Working mostly with TypeScript but a history with many other languages.",
+    "icon": "https://avatars.githubusercontent.com/u/880721?v=4",
+    "DonateLink": "https://buymeacoffee.com/jjdenhertog",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "jjdenhertog's Repository",
+    "index": 141
+  },
+  {
+    "url": "https://github.com/JmzTaylor/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/120824-jmztaylor/",
+    "bio": "Just kinda doing my own thing creating things for my use cases and sharing my work",
+    "icon": "https://raw.githubusercontent.com/jmztaylor/homelab_proxy_unraid/master/avatar.png",
+    "DonateLink": "https://paypal.me/jmztaylor",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "jmztaylor's Repository",
+    "index": 142
+  },
+  {
+    "url": "https://github.com/jgennari/UnraidApps",
+    "profile": "https://forums.unraid.net/profile/212091-joey-gennari/",
+    "bio": "Creating docker containers that I find help for web development.",
+    "icon": "https://1.gravatar.com/avatar/d37630c44ac1bf24b36dab00681eebfc0c0dd549b743f10b6552a405016138f0?size=512",
+    "title": "Joey Gennari's Repository",
+    "index": 143
+  },
+  {
+    "url": "https://github.com/jnbarlow/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/238964-john-barlow/",
+    "bio": "Adding a little spice to Unraid, one app at a time.",
+    "icon": "https://raw.githubusercontent.com/jnbarlow/unraid_templates/main/images/tick.jpg",
+    "DonateLink": "https://paypal.me/jnbarlow",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "John Barlow's Repository",
+    "index": 144
+  },
+  {
+    "url": "https://github.com/tenasi/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/121030-johnnyp/",
+    "bio": "Creating some docker containers that I use myself and want to share with others.",
+    "icon": "https://raw.githubusercontent.com/tenasi/unraid-templates/master/avatar.png",
+    "DonateLink": "https://www.paypal.me/tenasi",
+    "DonateText": "Buy me a beer.",
+    "title": "JohnnyP's Repository",
+    "index": 145
+  },
+  {
+    "url": "https://github.com/jordibrouwer/nextdash",
+    "profile": null,
+    "bio": "Made by Jordi Brouwer, nerd from The Netherlands.",
+    "icon": "https://avatars.githubusercontent.com/u/117413846?v=4",
+    "WebPage": "https://www.jordibrw.nl",
+    "title": "Jordibrw",
+    "index": 146
+  },
+  {
+    "url": "https://github.com/Josh5/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/76627-josh5/",
+    "bio": "Software Developer, DevOps Engineer and Electrical Technician. In my spare time I enjoy writing software for the open-source community. I deal a lot with Docker on a day-to-day basis and have experience in embedded Linux development.",
+    "icon": "https://raw.githubusercontent.com/Josh5/unraid-docker-templates/master/images/josh5.png",
+    "DonateLink": "https://ko-fi.com/josh5coffee",
+    "DonateText": "If you like my work, please consider supporting me on Patreon",
+    "Twitter": "https://twitter.com/jsunnex",
+    "Discord": "https://streamingtech.co.nz/discord",
+    "WebPage": "https://github.com/sponsors/Josh5/",
+    "title": "Josh.5's Repository",
+    "index": 147
+  },
+  {
+    "url": "https://github.com/JSONbored/awesome-unraid",
+    "profile": "https://forums.unraid.net/profile/261555-jsonbored/",
+    "bio": "JSONbored publishes Unraid-first All-in-One containers for self-hosted software that normally requires multi-container setup, manual dependency wiring, or compose-heavy deployment. The focus is practical homelab usability: simpler installation, sane defaults, honest documentation about tradeoffs, and support for advanced users who want to override pieces of the stack.",
+    "icon": "https://raw.githubusercontent.com/JSONbored/awesome-unraid/main/icons/profile.png",
+    "DonateLink": "https://ko-fi.com/jsonbored",
+    "DonateText": "If these AIO templates save you time, please consider supporting ongoing maintenance via Ko-fi (ko-fi.com/jsonbored) or Buy Me a Coffee (buymeacoffee.com/jsonbored).",
+    "Forum": "https://forums.unraid.net/profile/261555-jsonbored/",
+    "Twitter": "https://x.com/jsonbored",
+    "WebPage": "https://aethereal.dev",
+    "title": "JSONbored's Repository",
+    "index": 148
+  },
+  {
+    "url": "https://github.com/DatPat/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169502-jsrk/",
+    "bio": "I am just trying to learn. Not everything I am doing will be perfect right away but I am hoping to improve it over time.",
+    "icon": "https://i.imgur.com/y1D2enH.png",
+    "DonateLink": "https://paypal.me/",
+    "DonateText": "No donation needed.",
+    "WebPage": "https://github.com/DatPat/",
+    "title": "jsrk's Repository",
+    "index": 149
+  },
+  {
+    "url": "https://github.com/JTok/unraid-plugins",
+    "profile": " https://forums.unraid.net/profile/75269-jtok/",
+    "bio": "Developer of the **Unraid.Vmbackup** plugin which uses the **Unraid-Vmbackup** script behind the scenes.",
+    "icon": "https://github.com/JTok.png",
+    "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NG5HGW4Q3CZU4",
+    "DonateText": "Feel free to buy me a beer or coffee :-)",
+    "title": "JTok's Repository",
+    "index": 150
+  },
+  {
+    "url": "https://github.com/juchong/shapeshifter-docker-unraid",
+    "profile": "https://forums.unraid.net/profile/113997-juchong/",
+    "bio": "Sharing useful stuff for others to use on their projects.",
+    "icon": "https://en.gravatar.com/userimage/60078001/c46d1f59af45f33cff47f5354404e4e6.jpg",
+    "DonateLink": "https://www.paypal.com/paypalme/juchong",
+    "DonateText": "If one of my containers helped you out, please consider donating!",
+    "title": "juchong's Repository",
+    "index": 151
+  },
+  {
+    "url": "https://github.com/OpenSageTV/unRAID",
+    "profile": "https://forums.unraid.net/profile/125876-jusjoken/",
+    "bio": "Creating containers and other needed development mostly in the SageTV community",
+    "icon": "https://raw.githubusercontent.com/jusjoken/resources/main/HeadshotCartoon.jpg",
+    "DonateLink": "https://www.patreon.com/user?u=58035567",
+    "DonateText": "Support me on Patreon",
+    "title": "jusjoken's Repository",
+    "index": 152
+  },
+  {
+    "url": "https://github.com/jwillmer/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119261-jwillmer/",
+    "bio": "That's me, nothing more to add.",
+    "icon": "https://raw.githubusercontent.com/jwillmer/unraid-templates/main/images/jwillmer.jpg",
+    "Forum": "https://forums.unraid.net/topic/130458-support-nut-influxdbv2-exporter/",
+    "Twitter": "https://twitter.com/jenswillmer",
+    "WebPage": "https://jwillmer.de",
+    "title": "jwillmer's Repository",
+    "index": 153
+  },
+  {
+    "url": "https://github.com/kaedinger/unraid-ca-xml-templates",
+    "profile": null,
+    "bio": "Software architect of 35 years, now audio engineer, but still creating/maintaining own software products as well as open source.",
+    "icon": "https://raw.githubusercontent.com/kaedinger/unraid-ca-xml-templates/main/ca_profile.png",
+    "DonateLink": "https://www.paypal.me/kaedinger",
+    "DonateText": "If you appreciate my work please consider donating.",
+    "WebPage": "https://kaedinger.de",
+    "Photo": "https://raw.githubusercontent.com/kaedinger/unraid-ca-xml-templates/main/fieldolamps.png",
+    "Video": "https://www.youtube.com/watch?v=Q9WB53jlILQ",
+    "title": "kaedinger's Repository",
+    "index": 154
+  },
+  {
+    "url": "https://github.com/kieraneglin/unraid_ca",
+    "profile": "https://forums.unraid.net/profile/185979-kieran-e/",
+    "bio": "Developer and Linux ISO enthusiast.",
+    "icon": "https://raw.githubusercontent.com/kieraneglin/unraid_ca/master/images/avatar.png",
+    "title": "Kieran E's Repository",
+    "index": 155
+  },
+  {
+    "url": "https://github.com/hofq/docker-templates",
+    "profile": "https://forums.unraid.net/profile/112121-kippenhof/",
+    "bio": "Providing Small/unknown Docker images to the CA application to make them more accessible. If you have a problem with one of my templates, you can write me on Discord: Johannes Walther#",
+    "icon": "https://s.gravatar.com/avatar/f8186422310ef2c5f080314631055a23?s=350",
+    "DonateLink": "https://github.com/hofq/docker-templates/blob/main/Donations.md",
+    "DonateText": "Don't donate to me! Instead, please donate the creators of these amazing apps.",
+    "title": "Kippenhof's Repository",
+    "index": 156
+  },
+  {
+    "url": "https://github.com/Kizaing/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/129591-kizaing/",
+    "bio": "Helping developers dockerize their applications and make them easy to install for everyone everywhere",
+    "icon": "https://raw.githubusercontent.com/Kizaing/Unraid-Templates/main/avatar.jpg",
+    "Twitter": "https://twitter.com/Kizaing",
+    "title": "Kizaing's Repository",
+    "index": 157
+  },
+  {
+    "url": "https://github.com/davidjkling/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/293102-kling/",
+    "bio": "I just want nice things for Unraid.",
+    "icon": "https://raw.githubusercontent.com/davidjkling/unraid-templates/refs/heads/main/static/user_icon.png",
+    "Forum": "https://forums.unraid.net/topic/196521-support-kling-templates",
+    "title": "Kling's Repository",
+    "index": 158
+  },
+  {
+    "url": "https://github.com/Commifreak/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/140912-kluthr/",
+    "bio": "Trying to make the world a bit better",
+    "icon": "https://raw.githubusercontent.com/Commifreak/unraid-plugins/master/pp.png",
+    "DonateLink": "https://www.paypal.me/robinkluth",
+    "DonateText": "If you like my work please consider donating.",
+    "WebPage": "https://kluthr.de",
+    "title": "KluthR's Repository",
+    "index": 159
+  },
+  {
+    "url": "https://github.com/maschhoff/docker",
+    "profile": "https://forums.unraid.net/profile/71048-knex666/",
+    "bio": "Building Unraid-Dockers for my environment and my projects to share them with you.\n  Most about Smart Home or automation and some more fancy stuff",
+    "icon": "https://avatars1.githubusercontent.com/u/4007829?s=460&u=379ce5191167d7e875f81bda8f205246a9e85dee&v=4",
+    "DonateLink": "https://www.buymeacoffee.com/maschhoff",
+    "DonateText": "If you like my work buy me a Pizza ;)",
+    "WebPage": "https://www.cmais.de",
+    "title": "knex666's Repository",
+    "index": 160
+  },
+  {
+    "url": "https://github.com/Kreuzbube88/heltemplates",
+    "profile": "https://forums.unraid.net/profile/288986-kreuzbube88/",
+    "bio": "No coding background \u2014 everything I build is created with AI (Claude). I design containers that include exactly what I need; they might be useful for you too.",
+    "icon": "https://github.com/Kreuzbube88/heltemplates/blob/main/ca_profil.jpg?raw=true",
+    "DonateLink": "https://paypal.me/kreuzbube88",
+    "DonateText": "Feel free to buy me a Coffee if you like my work.",
+    "title": "Kreuzbube88's Repository",
+    "index": 161
+  },
+  {
+    "url": "https://github.com/Krillsson/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/285387-krillsson/",
+    "bio": "I'm primarily an App Developer but also a home server enthusiast. I've been tinkering on sys-API and Monitee for 10+ years now.",
+    "icon": "https://raw.githubusercontent.com/Krillsson/unraid-templates/refs/heads/main/ca_profile_avatar.png",
+    "DonateLink": "https://github.com/sponsors/Krillsson",
+    "DonateText": "Sponsorship will motivate me to continue working, adding features, improving performance and stability!",
+    "WebPage": "https://monitee.app/",
+    "title": "Krillsson's Repository",
+    "index": 162
+  },
+  {
+    "url": "https://github.com/kubedzero/unraid-community-apps-xml",
+    "profile": "https://forums.unraid.net/profile/12026-kubed_zero/",
+    "bio": "A curious Unraid plugin maintainer. Avoids unnecessary plugins.",
+    "icon": "https://raw.githubusercontent.com/kubedzero/unraid-community-apps-xml/main/GitHubAvatar.png",
+    "Forum": "https://forums.unraid.net/profile/12026-kubed_zero/",
+    "title": "kubed_zero's Repository",
+    "index": 163
+  },
+  {
+    "url": "https://github.com/kutzilla/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/129184-kutzilla/",
+    "bio": "Creating Unraid templates for my personal system. Maybe some of those templates are helpful for your purpose.",
+    "icon": "https://raw.githubusercontent.com/kutzilla/unraid-templates/master/images/avatar.jpg",
+    "title": "kutzilla's Repository",
+    "index": 164
+  },
+  {
+    "url": "https://github.com/L4stIdi0t/Unraid-template",
+    "profile": "https://forums.unraid.net/profile/122421-l4stidi0t/",
+    "bio": "Creating templates for containers which I am missing on CA.",
+    "icon": "https://github.com/l4stidi0t.png",
+    "Discord": "https://discord.com/invite/7QVzvjcDDM",
+    "title": "L4stIdi0t's Repository",
+    "index": 165
+  },
+  {
+    "url": "https://github.com/laromicas/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/172751-laromicas/",
+    "bio": "Passionate software developer constantly learning & improving. Experienced in Python, Java, NodeJS, Bash and any language I feel I need.",
+    "icon": "https://avatars.githubusercontent.com/u/2052864?v=4",
+    "DonateLink": "https://www.paypal.me/laromicas",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://github.com/laromicas",
+    "title": "laromicas' Repository",
+    "index": 166
+  },
+  {
+    "url": "https://github.com/Lazaros-Chalkidis/unraid-CA",
+    "profile": "https://forums.unraid.net/profile/170958-lazaros-chalkidis/",
+    "bio": "IT with 25+ years of experience. Specializing in WordPress security, malware removal, and servers management. Building open-source plugins for Unraid platform.",
+    "icon": "https://avatars.githubusercontent.com/u/263085199?v=4",
+    "title": "Lazaros Chalkidis' Repository",
+    "index": 167
+  },
+  {
+    "url": "https://github.com/LeonStoldt/Unraid-Community-Applications",
+    "profile": "https://forums.unraid.net/profile/170522-leonstoldt/",
+    "bio": "German Software Engineer",
+    "icon": "https://avatars.githubusercontent.com/u/31759512?v=4",
+    "DonateLink": "https://buymeacoffee.com/LeonStoldt",
+    "DonateText": "If you like my work please consider buying me a coffee.",
+    "WebPage": "https://leon-stoldt.de",
+    "title": "LeonStoldt's Repository",
+    "index": 168
+  },
+  {
+    "url": "https://github.com/linuxserver/templates",
+    "profile": null,
+    "bio": "We are a group of like minded enthusiasts from across the world who build and maintain the largest collection of Docker images on the web, and at our core are the principles behind Free and Open Source Software. Our primary goal is to provide easy-to-use and streamlined Docker images with clear and concise documentation.",
+    "icon": "https://github.com/linuxserver.png",
+    "DonateLink": "https://www.linuxserver.io/donate",
+    "DonateText": "Even the smallest donation from you will help us keep everything up and running so we can continue to provide our great services.",
+    "Forum": "https://discourse.linuxserver.io",
+    "Twitter": "https://twitter.com/linuxserverio",
+    "Discord": "https://discord.gg/YWrKVTn",
+    "WebPage": "https://www.linuxserver.io",
+    "title": "linuxserver's Repository",
+    "index": 169
+  },
+  {
+    "url": "https://github.com/iamlite/UnraidCA-GuppyFLO",
+    "profile": "https://forums.unraid.net/profile/275562-lite/",
+    "bio": "I break alot of stuff",
+    "icon": "https://github.com/iamlite/iamlite/blob/main/pfp.png?raw=true",
+    "title": "Lite's Repository",
+    "index": 170
+  },
+  {
+    "url": "https://github.com/ljm42/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/61877-ljm42/",
+    "bio": "These are my personal contributions to the community, not offical offerings by Lime Technologies",
+    "icon": "https://ipsassets.unraid.net/uploads/monthly_2020_12/Answer_to_Life.thumb.png.508f33beece2c22fb6dde4cf726a02f9.png",
+    "title": "ljm42's Repository",
+    "index": 171
+  },
+  {
+    "url": "https://github.com/llalon/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/126527-llalon/",
+    "bio": "i write software and software accessories",
+    "icon": "https://raw.githubusercontent.com/llalon/unraid-templates/master/llalon/images/profile.jpg",
+    "title": "llalon's Repository",
+    "index": 172
+  },
+  {
+    "url": "https://github.com/lnxd/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/114915-lnxd/",
+    "bio": "Unraid Fan. Timezone is GMT+11.",
+    "icon": "https://avatars.githubusercontent.com/u/48756329?s=500",
+    "DonateLink": "https://github.com/lnxd",
+    "DonateText": "If you like my work please consider donating.",
+    "title": "lnxd's Repository",
+    "index": 173
+  },
+  {
+    "url": "https://github.com/aglovewithoutlove/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/270452-logic_error/",
+    "bio": "Just trying to help out by adding missing templates for projects that I think are neat!",
+    "icon": "https://raw.githubusercontent.com/aglovewithoutlove/unraid-templates/refs/heads/main/profile.png",
+    "title": "logic_error's Repository",
+    "index": 174
+  },
+  {
+    "url": "https://github.com/lordfiSh/unraid-docker-images",
+    "profile": "https://forums.unraid.net/profile/92815-lordfish/",
+    "bio": "Unraid Docker images",
+    "icon": "https://raw.githubusercontent.com/lordfiSh/unraid-docker-images/main/images/avatar.jpg",
+    "DonateLink": "https://www.paypal.com/paypalme/imgeld",
+    "DonateText": "If you appreciate my work, then please consider buying me a beer :D",
+    "title": "lordfiSh's Repository",
+    "index": 175
+  },
+  {
+    "url": "https://github.com/lubeda/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/107977-lubeda/",
+    "bio": "I like home assistant and Unraid.",
+    "icon": "https://avatars.githubusercontent.com/u/17859549?s=60",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=FZDKSLQ46HJTU",
+    "DonateText": "If you like my work please consider donating.",
+    "title": "LuBeDa's Repository",
+    "index": 176
+  },
+  {
+    "url": "https://github.com/JamsRepos/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
+    "bio": "A collection of Unraid templates that I use and maintain.  I am always looking for feedback and suggestions for improvements and additional templates.",
+    "icon": "https://avatars.githubusercontent.com/u/1347620?v=4",
+    "DonateLink": "https://github.com/sponsors/JamsRepos",
+    "DonateText": "Feeling generous?  Consider sponsoring me on GitHub!",
+    "Forum": "https://github.com/JamsRepos/Unraid-Templates/issues",
+    "WebPage": "https://github.com/JamsRepos/Unraid-Templates",
+    "title": "LubricantJam's Repository",
+    "index": 177
+  },
+  {
+    "url": "https://github.com/luigi311/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/72460-luigi311/",
+    "bio": "I am a software developer with a focus on creating and supporting open source projects with a focus on media related projects.",
+    "WebPage": "https://github.com/luigi311",
+    "title": "Luigi311's Repository",
+    "index": 178
+  },
+  {
+    "url": "https://github.com/logandwaters/Plug-and-Play-Docker",
+    "profile": "https://forums.unraid.net/profile/281787-lwater/",
+    "bio": "I mostly create custom templates for other software, following my Plug-and-Play (PnP) rules\u2014designed to embody the simplicity Unraid apps should offer, with easy installation and minimal tinkering. While my focus is on templates, I also develop my own software occasionally. My goal is to streamline setup so users enjoy hassle-free experiences.",
+    "icon": "https://raw.githubusercontent.com/logandwaters/Plug-and-Play-Docker/refs/heads/main/profile/profile_picture.jpg",
+    "DonateLink": "https://www.paypal.me/logandwateres",
+    "DonateText": "I create software, templates, and tools\u2014both for my projects and to complement others' work. If you find them useful, please consider donating to support my efforts. While I build templates for other software, remember to also support the original creators of the tools you enjoy!",
+    "title": "lwater's Repository",
+    "index": 179
+  },
+  {
+    "url": "https://github.com/m0ngr31/unraid_ca",
+    "profile": "https://forums.unraid.net/profile/75617-m0ngr31/",
+    "bio": "Creating apps as I see a need for them.",
+    "icon": "https://avatars.githubusercontent.com/u/1045977?v=4",
+    "Forum": "https://forums.unraid.net/topic/149018-support-m0ngr31-dockers/",
+    "WebPage": "https://github.com/m0ngr31",
+    "title": "m0ngr31's Repository",
+    "index": 180
+  },
+  {
+    "url": "https://github.com/Oratorian/unraid-templates",
+    "profile": null,
+    "bio": "Open-source projects from Oratorian. Currently maintaining emby-watchparty, a synchronized watch-party frontend for Emby media servers that lets you watch videos with friends in real time without giving them Emby accounts. The Emby server stays on your local network, the watch party app proxies HLS streams to guests, and play/pause/seek stay synchronized across every viewer. For support, please use the linked Unraid forum thread (preferred) or open an issue on GitHub.",
+    "icon": "https://raw.githubusercontent.com/Oratorian/emby-watchparty/main/static/favicon.ico",
+    "DonateLink": "https://ko-fi.com/jedziah",
+    "DonateText": "Support development on Ko-fi",
+    "Forum": "https://forums.unraid.net/topic/198376-support-emby-watchparty-watch-party-for-emby-synchronized-playback/",
+    "Discord": "https://discord.gg/RWUpxq9xsA",
+    "WebPage": "https://github.com/Oratorian",
+    "title": "Mahesvara's Toolshed",
+    "index": 181
+  },
+  {
+    "url": "https://github.com/Mainfrezzer/UnRaid-Templates/",
+    "profile": "https://forums.unraid.net/profile/201895-mainfrezzer/",
+    "bio": "I like to tinker around to solve my problems.",
+    "icon": "https://raw.githubusercontent.com/Mainfrezzer/UnRaid-Templates/main/icon/avatar.png",
+    "title": "Mainfrezzer's Repository",
+    "index": 182
+  },
+  {
+    "url": "https://github.com/mak-cs/unraid",
+    "profile": "https://forums.unraid.net/profile/269540-mak-cs/",
+    "bio": "I create templates of Docker containers to solve my Unraid requirements. If you find them useful, feel free to use them.",
+    "icon": "https://raw.githubusercontent.com/mak-cs/unraid/master/icons/mak.png",
+    "DonateLink": "https://paypal.me/makcs",
+    "DonateText": "If you like my work, please consider making a donation.",
+    "title": "MAK-CS' Repository",
+    "index": 183
+  },
+  {
+    "url": "https://github.com/manuel-rw/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/138040-manrw/",
+    "bio": "C# Software Engineer from Switzerland, loves to code and watch Anime. Contributes to open source projects.",
+    "icon": "https://github.com/manuel-rw.png",
+    "DonateLink": "https://ko-fi.com/manicraft1001",
+    "DonateText": "Please donate me a coffee if you like my work!",
+    "Discord": "https://discord.gg/hRHZ3q3VDX",
+    "title": "manrw's Repository",
+    "index": 184
+  },
+  {
+    "url": "https://github.com/mmartial/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/15ho4534-martial/",
+    "bio": "Enthusiastic self-hoster, Researcher, Developer, with a passion for teaching (see my blog \ud83d\ude0a) ... a geekier profile \ud83d\ude80",
+    "icon": "https://raw.githubusercontent.com/mmartial/unraid-templates/master/templates/assets/MM.jpg",
+    "WebPage": "https://www.gkr.one/",
+    "title": "martial's Repository",
+    "index": 185
+  },
+  {
+    "url": "https://github.com/marzel1/docker-templates",
+    "profile": "https://forums.unraid.net/profile/117249-marzel/",
+    "bio": "Hobbyist self-hoster.",
+    "icon": "https://raw.githubusercontent.com/marzel1/docker-templates/main/marzel/img/marzel.jpg",
+    "Forum": "https://forums.unraid.net/topic/107813-support-marzel-remotely/",
+    "WebPage": "https://forums.unraid.net/profile/117249-marzel/",
+    "title": "Marzel's Repository",
+    "index": 186
+  },
+  {
+    "url": "https://github.com/masterwishx/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/107418-masterwishx/",
+    "bio": "Creator of a few Unraid Templates.",
+    "icon": "https://github.com/masterwishx.png",
+    "title": "Masterwishx's Repository",
+    "index": 187
+  },
+  {
+    "url": "https://github.com/MattFaz/unraid_templates/",
+    "profile": "https://forums.unraid.net/profile/76145-mattfaz/",
+    "bio": "Creating DOcker Containers that I personally use.",
+    "icon": "https://raw.githubusercontent.com/MattFaz/unraid_templates/main/images/profile.png",
+    "Forum": "https://forums.unraid.net/topic/144385-support-mattfaz-repo/",
+    "title": "MattFaz's Repository",
+    "index": 188
+  },
+  {
+    "url": "https://github.com/MattyStacks/docker-templates",
+    "profile": "https://forums.unraid.net/profile/9036-mattystacks/",
+    "bio": "MattyStacks' Docker Templates for Unraid",
+    "icon": "https://raw.githubusercontent.com/MattyStacks/docker-templates/main/MattyStacks/images/MattyStacks.jpg",
+    "title": "MattyStacks's Repository",
+    "index": 189
+  },
+  {
+    "url": "https://github.com/Mavrag/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/111982-mavrag/",
+    "bio": "I create Docker templates for Unraid.",
+    "icon": "https://raw.githubusercontent.com/mavrag/unraid-templates/master/mavrag_logo.png",
+    "DonateLink": "https://paypal.me/mavrag",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Mavrag's Repository",
+    "index": 190
+  },
+  {
+    "url": "https://github.com/mcreekmore/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/216090-mcreekmore/",
+    "bio": "Filling gaps wherever I find them :)",
+    "icon": "https://avatars.githubusercontent.com/u/48491595?v=4",
+    "DonateLink": "https://www.paypal.com/donate/?business=PNX6CA3TXGT2S&no_recurring=0&currency_code=USD",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "mcreekmore's Repository",
+    "index": 191
+  },
+  {
+    "url": "https://github.com/silkyclouds/unraid-disk-talkers",
+    "profile": null,
+    "bio": "Building stuff I need.",
+    "icon": "https://github.com/silkyclouds.png",
+    "title": "meaning's Repository",
+    "index": 192
+  },
+  {
+    "url": "https://github.com/medzin/docker-templates",
+    "profile": "https://forums.unraid.net/profile/293048-medzin/",
+    "bio": "Hobbyist and home lab enthusiast creating Docker templates to simplify self-hosted deployments for the community.",
+    "icon": "https://raw.githubusercontent.com/medzin/docker-templates/main/images/profile-icon.png",
+    "Twitter": "https://x.com/m3d21n",
+    "title": "medzin's Repository",
+    "index": 193
+  },
+  {
+    "url": "https://github.com/Memtly/Memtly.Unraid",
+    "profile": null,
+    "bio": "Software developer by day, software developer by night...",
+    "icon": "https://raw.githubusercontent.com/Memtly/Memtly.Assets/master/Logos/Community/Memtly.png",
+    "DonateLink": "https://buymeacoffee.com/memtly",
+    "DonateText": "BuyMeACoffee",
+    "WebPage": "https://github.com/Memtly",
+    "title": "Memtly's Repository",
+    "index": 194
+  },
+  {
+    "url": "https://github.com/mgutt/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/94359-mgutt",
+    "bio": "German Developer",
+    "icon": "https://raw.githubusercontent.com/mgutt/unraid-docker-templates/main/mgutt/images/avatar.jpg",
+    "DonateLink": "https://www.paypal.me/marcgutt",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://gutt.it/",
+    "title": "mgutt's Repository",
+    "index": 195
+  },
+  {
+    "url": "https://github.com/MiranoVerhoef/Unraid-Mirano",
+    "profile": "https://forums.unraid.net/profile/96734-mirano/",
+    "bio": "Helping out the community by creating CA Templates, whereas no one has made one yet.",
+    "icon": "https://raw.githubusercontent.com/MiranoVerhoef/Unraid-Mirano/main/ca_profile/Avatar.jpeg",
+    "Forum": "https://forums.unraid.net/topic/150080-support-mirano-docker-containers/",
+    "WebPage": "https://github.com/MiranoVerhoef/Unraid-Mirano",
+    "title": "Mirano's Repository",
+    "index": 196
+  },
+  {
+    "url": "https://github.com/mmenanno/unraid-templates",
+    "profile": null,
+    "bio": "A small, hand-maintained collection of Unraid Community Applications templates for containers I build and publish under github.com/mmenanno. Each app has its own upstream GitHub repo where development, releases, and support happen; the template's Support button links there, and that's the right place to file bugs or request features. New apps are added as I publish them.",
+    "icon": "https://github.com/mmenanno.png",
+    "DonateLink": "https://buymeacoffee.com/mmenanno",
+    "DonateText": "Buy me a coffee",
+    "WebPage": "https://github.com/mmenanno/unraid-templates",
+    "title": "mmenanno's Repository",
+    "index": 197
+  },
+  {
+    "url": "https://github.com/MountainGod2/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/167420-mrslaw/",
+    "bio": "Unraid enthusiast and IBRACORP team member. Join the Discord!",
+    "icon": "https://raw.githubusercontent.com/MountainGod2/unraid-templates/main/MG_Logo.png",
+    "DonateLink": "https://paypal.me/ibracorp",
+    "DonateText": "If you like their work, please consider donating.",
+    "Discord": "https://discord.gg/VWAG7rZ",
+    "WebPage": "https://ibracorp.io",
+    "title": "mrslaw's Repository",
+    "index": 198
+  },
+  {
+    "url": "https://github.com/n8detar/docker-templates",
+    "profile": "https://forums.unraid.net/profile/104222-ndetar/",
+    "bio": "I am not really a developer, I just made someone elses docker container available to others in the Unraid Community, I hope it helps!",
+    "icon": "https://raw.githubusercontent.com/n8detar/docker-templates/master/n8detar/images/avatar.png",
+    "title": "ndetar's Repository",
+    "index": 199
+  },
+  {
+    "url": "https://github.com/NightMeer/Unraid-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/191921-nightmeer/",
+    "bio": "Creating Containers and Plugins.",
+    "icon": "https://raw.githubusercontent.com/NightMeer/Unraid-Docker-Templates/main/images/avatar.png",
+    "DonateLink": "https://paypal.me/nightmeer",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "NightMeer's Repository",
+    "index": 200
+  },
+  {
+    "url": "https://github.com/ninthwalker/docker-templates",
+    "profile": "https://forums.unraid.net/profile/9420-ninthwalker/",
+    "bio": "Creating bots, scripts, dockers and other small projects",
+    "icon": "https://raw.githubusercontent.com/ninthwalker/github/main/img/brentsflix/bfx.png",
+    "DonateLink": "https://github.com/sponsors/ninthwalker",
+    "DonateText": "Donations are definitely not required, but much appreciated!",
+    "title": "ninthwalker's Repository",
+    "index": 201
+  },
+  {
+    "url": "https://github.com/nodiaque/unraid_template",
+    "profile": "https://forums.unraid.net/profile/147860-nodiaque/",
+    "bio": "Creating Containers to benefit the Unraid Community",
+    "icon": "https://raw.githubusercontent.com/nodiaque/unraid_template/master/nodiaque/images/avatar.png",
+    "DonateLink": "https://paypal.me/nodiaque",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Nodiaque's Repository",
+    "index": 202
+  },
+  {
+    "url": "https://github.com/nulcraft/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/88507-nulcraft/",
+    "bio": "Building self-hosted tools focused on simplicity and automation. The goal is always the same: less manual work, more control, and no unnecessary complexity. I believe good software should get out of your way and just work, letting you focus on what actually matters instead of managing the tools themselves.",
+    "icon": "https://github.com/nulcraft.png",
+    "title": "nulcraft's Repository",
+    "index": 203
+  },
+  {
+    "url": "https://github.com/photostructure/unraid-template",
+    "profile": "https://forums.unraid.net/profile/116201-mrm/",
+    "shortName": "PhotoStructure",
+    "bio": "Building PhotoStructure, your new home for your family's photos and videos.",
+    "icon": "https://photostructure.com/img/2020/08/mrm-256w.jpg",
+    "DonateLink": "https://photostructure.com/pricing",
+    "DonateText": "PhotoStructure is completely subscriber-supported!",
+    "Reddit": "https://reddit.com/r/PhotoStructure/",
+    "Twitter": "https://twitter.com/PhotoStructure",
+    "Discord": "https://discord.gg/gU9h8uQTYw",
+    "WebPage": "https://photostructure.com",
+    "title": "Official PhotoStructure Repository",
+    "index": 204
+  },
+  {
+    "url": "https://github.com/unraid/language-templates",
+    "profile": null,
+    "shortName": "Unraid",
+    "bio": "Lime Technology Inc is the maker of Unraid OS. Unraid is an OS for personal and small business use that brings enterprise-class features letting you configure your computer systems to maximize performance and capacity using any combination of applications, VMs, storage devices, and hardware.",
+    "icon": "https://craftassets.unraid.net/uploads/Social-Circle-@2x.png",
+    "Facebook": "https://www.facebook.com/UnraidOfficial",
+    "Reddit": "https://www.reddit.com/r/unRAID/",
+    "Forum": "https://forums.unraid.net/",
+    "Twitter": "https://twitter.com/UnraidOfficial",
+    "WebPage": "https://unraid.net/",
+    "title": "Official Unraid Repository",
+    "index": 205
+  },
+  {
+    "url": "https://github.com/Organizr/docker-organizr",
+    "profile": null,
+    "bio": "Creating official Docker images for the Organizr application.",
+    "icon": "https://raw.githubusercontent.com/causefx/Organizr/v2-master/plugins/images/organizr/logo-no-border.png",
+    "DonateLink": "https://paypal.me/causefx",
+    "DonateText": "If you like my work please consider Donating.",
+    "Discord": "https://organizr.app/discord",
+    "WebPage": "https://organizr.app/",
+    "title": "Organizr Repository",
+    "index": 206
+  },
+  {
+    "url": "https://github.com/oromis995/UnraidKoboldCpp",
+    "profile": "https://forums.unraid.net/profile/108450-oromis95/",
+    "bio": "AI Software Engineer, if you seek me for non-business reasons, Discord is the best place to reach me, where I'm oromis95.",
+    "icon": "https://avatars.githubusercontent.com/u/54419741?s=400&u=63f1e75cc721abe46f6af39936eb9670a00aed64&v=4",
+    "title": "oromis95's Repository",
+    "index": 207
+  },
+  {
+    "url": "https://github.com/Pa7rickStar/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/288616-pa7rickstar/",
+    "bio": "Creating Docker containers from the comfort of my pineapple. I always try to make containers which work out of the box and use official sources as much as possible.",
+    "icon": "https://raw.githubusercontent.com/Pa7rickStar/unraid_templates/refs/heads/main/images/avatar.png",
+    "DonateLink": "https://buymeacoffee.com/pa7rickstar",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Pa7ricstar's Repository",
+    "index": 208
+  },
+  {
+    "url": "https://github.com/paulpoco/docker-templates",
+    "profile": "https://forums.unraid.net/profile/69794-paul_ber/",
+    "bio": "Just adapting existing DockerHub images and doing the Templates for Unraid",
+    "icon": "https://raw.githubusercontent.com/paulpoco/docker-templates/master/paulpoco/images/pjbwidgets_web_hi_res_512.png",
+    "title": "Paul_Ber's Repository",
+    "index": 209
+  },
+  {
+    "url": "https://github.com/imTHAI/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/117577-pbear/",
+    "bio": "Mai pen rai.",
+    "icon": "https://raw.githubusercontent.com/imTHAI/unraid-templates/main/me_bw.png",
+    "title": "pbear's Repository",
+    "index": 210
+  },
+  {
+    "url": "https://github.com/PerpetualSoftware/unraid-templates",
+    "profile": null,
+    "bio": "Perpetual Software ships local-first developer tools that respect your data and run on hardware you control. This repository holds our Unraid Community Applications templates.",
+    "icon": "https://raw.githubusercontent.com/PerpetualSoftware/unraid-templates/main/icon.png",
+    "Forum": "https://forums.unraid.net/topic/198646-support-pad-local-first-project-management-for-developers-and-ai-agents/",
+    "WebPage": "https://perpetualsoftware.org",
+    "title": "Perpetual Software's Repository",
+    "index": 211
+  },
+  {
+    "url": "https://github.com/petersem/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/240191-petersem/",
+    "bio": "I.T Architect, Coder, geek, dad, rev-head, sci-fi guy, and lover of great wines and whiskey. ;)",
+    "icon": "https://avatars.githubusercontent.com/u/1418289?v=4",
+    "DonateLink": "https://www.paypal.com/paypalme/thanksmp",
+    "DonateText": "If you like my work please consider Donating.",
+    "Discord": "https://discord.gg/TcnEkMEf9J",
+    "title": "petersem's Repository",
+    "index": 212
+  },
+  {
+    "url": "https://github.com/Peuuuur-Noel/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/155305-peuuuur-noel/",
+    "bio": "Blue marmot.",
+    "icon": "https://github.com/peuuuur-noel.png",
+    "title": "Peuuuur Noel's Repository",
+    "index": 213
+  },
+  {
+    "url": "https://github.com/Phalcode/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/266495-phalcode/",
+    "bio": "small software development team, from germany, consisting of 2 people, publishing their applications.",
+    "icon": "https://github.com/phalcode.png",
+    "DonateLink": "https://phalco.de/support-us",
+    "DonateText": "If you like our work please consider donating.",
+    "Reddit": "https://reddit.com/r/phalcode",
+    "Discord": "https://discord.gg/NEdNen2dSu",
+    "title": "phalcode's Repository",
+    "index": 214
+  },
+  {
+    "url": "https://github.com/Phil-Barker/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/211519-philbarker/",
+    "bio": "Just an ex-developer, now CTO, who loves tinkering with Unraid in his spare time.",
+    "icon": "https://phil-barker.com/assets/img/1.png",
+    "title": "PhilBarker's Repository",
+    "index": 215
+  },
+  {
+    "url": "https://github.com/pierot/unraid-ca-apps",
+    "profile": "https://forums.unraid.net/profile/121203-pieterm/",
+    "bio": "Building, automating, tinkering.",
+    "icon": "https://avatars.githubusercontent.com/u/46622?v=4",
+    "WebPage": "https://noort.be",
+    "title": "pieterm's Repository",
+    "index": 216
+  },
+  {
+    "url": "https://github.com/PikkonMG/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/75476-pikkonmg/",
+    "bio": "Creating Docker containers and templates for Unraid",
+    "icon": "https://raw.githubusercontent.com/PikkonMG/unraid-docker-templates/main/templates/img/faqfirebase_512x512.png",
+    "DonateLink": "https://paypal.me/HighlandJewls",
+    "DonateText": "Templates are free, coffee is optional",
+    "title": "PikkonMG's Repository",
+    "index": 217
+  },
+  {
+    "url": "https://github.com/noinip/container-templates",
+    "profile": "https://forums.unraid.net/profile/10946-pinion/",
+    "bio": "I started when Docker came on the scene with Unraid some 7 or so years ago. CherryMusic and pyTiVo are my main two and I plan to revisit them now in 2021/22.",
+    "icon": "https://forums.unraid.net/uploads/monthly_2020_11/ring-and-pinion-set-alt-v2.jpg.67cc28c50f97467b1f4369c7e8e9b297.jpg",
+    "title": "pinion's Repository",
+    "index": 218
+  },
+  {
+    "url": "https://github.com/PlazzmiK/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/268068-plazzmik/",
+    "bio": "Checking and adding docker containers to Unraid that I personaly use...",
+    "icon": "https://raw.githubusercontent.com/PlazzmiK/unraid_templates/main/images/profile.png",
+    "DonateLink": "https://www.Teunis.be",
+    "DonateText": "Check out my other stuff.",
+    "WebPage": "https://www.Teunis.be",
+    "title": "Plazzmik's Repository",
+    "index": 219
+  },
+  {
+    "url": "https://github.com/PTRFRLL/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/75102-ptrfrll",
+    "bio": "Giving back to the Unraid community, one application at a time.",
+    "icon": "https://raw.githubusercontent.com/PTRFRLL/unraid-templates/master/assets/icon.png",
+    "DonateLink": "https://www.paypal.me/ptrfrll",
+    "DonateText": "Buy me a coffee/beer",
+    "WebPage": "https://github.com/PTRFRLL",
+    "title": "PTRFRLL's Repository",
+    "index": 220
+  },
+  {
+    "url": "https://github.com/ds-sebastian/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/238004-pureelectricity/",
+    "bio": "Data Scientist and Sys admin cosplayer. I like to self-host",
+    "icon": "https://media.invisioncic.com/u329766/monthly_2025_01/majora.jpg.5c3594f3f16f52ae462e3653f4c5a760.jpg",
+    "WebPage": "https://github.com/ds-sebastian",
+    "title": "pureelectricity's Repository",
+    "index": 221
+  },
+  {
+    "url": "https://github.com/pyrater/docker-templates",
+    "profile": "https://forums.unraid.net/profile/14118-pyrater/",
+    "bio": "Lets do this.",
+    "icon": "https://raw.githubusercontent.com/pyrater/docker-templates/main/pyrater.png",
+    "title": "pyrater's Repository",
+    "index": 222
+  },
+  {
+    "url": "https://github.com/gjhami/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/281298-raidingunraid/",
+    "bio": "Penetration tester and researcher interested in making containers for the security conscious.",
+    "icon": "https://www.dictionary.com/e/wp-content/uploads/2018/03/thisisfine-1.jpg",
+    "title": "raidingUnraid's Repository",
+    "index": 223
+  },
+  {
+    "url": "https://github.com/RandomNinjaAtk/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/9890-randomninjaatk/",
+    "bio": "Integrating scripts to enhance existing docker containers functionality.",
+    "icon": "https://avatars0.githubusercontent.com/u/8386416",
+    "DonateLink": "https://github.com/sponsors/RandomNinjaAtk",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "randomninjaatk's Repository",
+    "index": 224
+  },
+  {
+    "url": "https://github.com/RazorSiM/docker-templates",
+    "profile": "https://forums.unraid.net/profile/84655-raz/",
+    "bio": "Random Docker containers template for applications I like.",
+    "icon": "https://github.com/RazorSiM/docker-templates/raw/master/razLogo.png",
+    "DonateLink": "https://paypal.me/simonecolabufalo",
+    "DonateText": "If you want to have a beer with me, you're always welcome :)",
+    "Discord": "https://discord.gg/Mn2Ty3y",
+    "WebPage": "https://raz.wtf",
+    "title": "raz's Repository",
+    "index": 225
+  },
+  {
+    "url": "https://github.com/redvex2460/docker-templates",
+    "profile": "https://forums.unraid.net/profile/128113-redvex/",
+    "bio": "Creating Containers and Plugins with the intention to make them as easy as possible to install and use.",
+    "icon": "https://raw.githubusercontent.com/redvex2460/docker-templates/main/redvex/images/avatar.jpg",
+    "DonateLink": "https://paypal.me/RedVex2460Gaming",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "RedVex's Repository",
+    "index": 226
+  },
+  {
+    "url": "https://github.com/rix1337/docker-templates",
+    "profile": "https://forums.unraid.net/profile/67339-rix/",
+    "bio": "I love automation. What is not there, I create myself. I only answer support queries on GitHub.",
+    "icon": "https://github.com/rix1337.png",
+    "DonateLink": "https://github.com/users/rix1337/sponsorship",
+    "DonateText": "Sponsor me if you like my work!",
+    "title": "rix's Repository",
+    "index": 227
+  },
+  {
+    "url": "https://github.com/robotfishe/robotfishe-unraid-apps",
+    "profile": "https://forums.unraid.net/profile/204504-robotfishe/",
+    "bio": "Contributing anything I cobble together for my own Unraid use in case it might help someone else.",
+    "title": "robotfishe's Repository",
+    "index": 228
+  },
+  {
+    "url": "https://github.com/Data-Monkey/docker-templates",
+    "profile": "https://forums.unraid.net/profile/62021-roland/",
+    "bio": "I am not attempting to create containers, but I have built a few templates to make life a little easier. If you are looking for details on the containers, please check out the individual DockerHub pages.\n    There is usually also a support thread linked in the respectiuve template.",
+    "icon": "https://ipsassets.unraid.net/uploads/monthly_2017_02/DataMonkey.gif.2e58e2d34570035409850b750e2b4ae2.gif",
+    "title": "Roland's Repository",
+    "index": 229
+  },
+  {
+    "url": "https://github.com/rroller/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/75343-runraid/",
+    "bio": "Adding missing containers as I find and need them.",
+    "icon": "https://i.imgur.com/ZjNRfo3.png",
+    "WebPage": "https://ronnieroller.com",
+    "title": "runraid's Repository",
+    "index": 230
+  },
+  {
+    "url": "https://github.com/catapultcase/Unraid_CommunityApplications",
+    "profile": "https://forums.unraid.net/profile/83669-rusty6285/",
+    "bio": "Hardware enthusiast and developer of JunctionRelay, an open source platform for real-time device and sensor coordination.",
+    "icon": "https://catapultcase.com/wp-content/uploads/2025/05/jr_logo-scaled.png",
+    "DonateLink": "https://buymeacoffee.com/catapultcase",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Rusty6285's Repository",
+    "index": 231
+  },
+  {
+    "url": "https://github.com/desertwitch/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/115350-rysz/",
+    "bio": "Hi, I'm Rysz - a data storage and open source enthusiast from Europe.\n    I mainly focus on bringing software to the Unraid OS ecosystem, with plugins now enhancing more than 20,000 servers.\n    I'm passionate about contributing to open source projects, the Go programming language and working with UPS devices.",
+    "icon": "https://raw.githubusercontent.com/desertwitch/unraid-plugins/main/avatar.jpg",
+    "WebPage": "https://desertwitch.github.io/unraid-projects/",
+    "title": "Rysz's Repository",
+    "index": 232
+  },
+  {
+    "url": "https://github.com/Sander0542/docker-templates",
+    "profile": "https://forums.unraid.net/profile/98342-sander0542/",
+    "bio": "Developer who likes to create usefull tools and share them with the world.",
+    "icon": "https://github.com/Sander0542.png",
+    "DonateLink": "https://github.com/sponsors/Sander0542",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Sander0542's Repository",
+    "index": 233
+  },
+  {
+    "url": "https://github.com/ivaxor/unraid-ca-docker-templates",
+    "profile": "https://forums.unraid.net/profile/147445-saskiuhia/",
+    "bio": "We are a few man that know how to use a computer at max. Mainly we are developing products for ourselfs. But sometimes they come to a big world of open-source.",
+    "icon": "https://raw.githubusercontent.com/ivaxor/press-assets-information/master/icons/logo.png",
+    "DonateLink": "https://github.com/sponsors/ivaxor",
+    "DonateText": "Sponsor me if you like my work!",
+    "title": "saskiuhia's Repository",
+    "index": 234
+  },
+  {
+    "url": "https://github.com/Schaka/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/243152-schaka/",
+    "bio": "Creating a variety of useful self-hosted apps.",
+    "icon": "https://raw.githubusercontent.com/Schaka/unraid-templates/main/schaka.jpg",
+    "WebPage": "https://github.com/Schaka",
+    "title": "Schaka's Repository",
+    "index": 235
+  },
+  {
+    "url": "https://github.com/sceather/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/87682-scootter/",
+    "bio": "I couldn't find some Unraid Templates so I created them myself. Definitely not an expert but maybe these can help someone else.",
+    "icon": "https://raw.githubusercontent.com/sceather/unraid-templates/refs/heads/main/images/scootter.png",
+    "title": "Scootter's Repository",
+    "index": 236
+  },
+  {
+    "url": "https://github.com/Sdub76/unraid_docker_templates",
+    "profile": "https://forums.unraid.net/profile/113369-sdub",
+    "bio": "My template respository to fill gaps I find in the CA store",
+    "icon": "https://avatars0.githubusercontent.com/u/11237911",
+    "DonateLink": "https://paypal.me/ScottWaun",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://github.com/Sdub76/unraid_docker_templates",
+    "title": "sdub's Repository",
+    "index": 237
+  },
+  {
+    "url": "https://github.com/selfhosters/unRAID-CA-templates",
+    "profile": null,
+    "shortName": "Selfhosters",
+    "bio": "A bunch of happy folks adding what the community want, to give them choice, for free. Request stuff on our github https://github.com/selfhosters/Unraid-CA-templates",
+    "icon": "https://github.com/selfhosters.png",
+    "Forum": "https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/",
+    "Discord": "https://discord.gg/qWPbc8R",
+    "WebPage": "https://selfhosters.net/",
+    "title": "Selfhosters Unraid Discord Repository",
+    "index": 238
+  },
+  {
+    "url": "https://github.com/xshatterx/Seraphys",
+    "profile": "https://forums.unraid.net/profile/275245-seraphys/",
+    "bio": "Docker Master",
+    "icon": "https://github.com/xshatterx.png",
+    "title": "Seraphys' Repository",
+    "index": 239
+  },
+  {
+    "url": "https://github.com/seriousm4x/unraid-community-apps",
+    "profile": "https://forums.unraid.net/profile/246841-seriousm4x/",
+    "bio": "\ud83c\udfa5 Audio visual media designer (cutter and camera guy) from Germany\n        \ud83e\udd16 Very interested in Open Source AI projects like whisper\n        \ud83d\udd25 Arch (btw) for both, programming and video editing in Davinci Resolve\n        \u2615 Coffee enjoyer",
+    "icon": "https://avatars.githubusercontent.com/u/23456686?v=4",
+    "DonateLink": "https://github.com/seriousm4x#want-to-buy-me-a--",
+    "DonateText": "Want to support my work? Buy me a coffee on ko-fi or become a Github Sponsor.",
+    "Reddit": "https://www.reddit.com/user/SeriousM4x",
+    "Twitter": "https://twitter.com/SeriousM4x",
+    "title": "seriousm4x's Repository",
+    "index": 240
+  },
+  {
+    "url": "https://github.com/sgraaf/Unraid-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/119190-sgraaf/",
+    "bio": "I create templates for any Docker containers that I use that are not yet\n    listed on CA.",
+    "icon": "https://github.com/sgraaf.png",
+    "DonateLink": "https://www.paypal.me/sgraaf2",
+    "DonateText": "Help support my work by buying me a coffee or a beer",
+    "title": "sgraaf's Repository",
+    "index": 241
+  },
+  {
+    "url": "https://github.com/ShaneIsrael/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/168827-shane-israel/",
+    "bio": "I just like creating useful software to that solves my own problems, and then sharing it with everyone else.",
+    "icon": "https://raw.githubusercontent.com/shaneisrael/unraid-templates/master/images/avatar.png",
+    "DonateLink": "https://buymeacoffee.com/shaneisrael",
+    "DonateText": "If you like my work please consider buying me a coffee. Thank you!",
+    "title": "Shane Israel's Repository",
+    "index": 242
+  },
+  {
+    "url": "https://github.com/m3ue/m3u-editor",
+    "profile": "https://forums.unraid.net/profile/292018-shparkison/",
+    "bio": "Official m3u editor application maintained by sparkison.\n    Full featured IPTV playlist editor and proxy server.",
+    "icon": "https://raw.githubusercontent.com/sparkison/m3u-editor/refs/heads/master/public/logo.png",
+    "DonateLink": "https://ko-fi.com/sparkison",
+    "DonateText": "If you like my work please consider Donating.",
+    "Discord": "https://discord.gg/rS3abJ5dz7",
+    "title": "shparikson's Repository",
+    "index": 243
+  },
+  {
+    "url": "https://github.com/simonjenny/unraid",
+    "profile": "https://forums.unraid.net/profile/122229-simon-jenny/",
+    "bio": "Swiss Developer",
+    "icon": "https://raw.githubusercontent.com/simonjenny/unraid/main/avatar.jpg",
+    "WebPage": "https://simonjenny.dev",
+    "title": "Simon Jenny's Repository",
+    "index": 244
+  },
+  {
+    "url": "https://github.com/Skylinar/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/109199-skylinar/",
+    "bio": "I maintain templates for some of my favorite services and hope you'll find them enjoyable too.",
+    "icon": "https://raw.githubusercontent.com/Skylinar/unraid_templates/refs/heads/main/images/profile.jpeg?raw=true",
+    "DonateLink": "https://ko-fi.com/skylinar",
+    "DonateText": "If you find my work helpful, consider buying me a coffee!",
+    "Forum": "https://forums.unraid.net/topic/193655-support-skylinars-repository/",
+    "WebPage": "https://github.com/Skylinar",
+    "title": "Skylinar's Repository",
+    "index": 245
+  },
+  {
+    "url": "https://github.com/slamanna212/UnraidTemplates",
+    "profile": "https://forums.unraid.net/profile/106550-slamanna212/",
+    "bio": "Niche Docker containers are my jam!",
+    "icon": "https://github.com/slamanna212/UnraidTemplates/blob/main/avatar.png?raw=true",
+    "title": "slamanna212's Repository",
+    "index": 246
+  },
+  {
+    "url": "https://github.com/MasterEvarior/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/140790-smithynithy/",
+    "bio": "Just doing my part!",
+    "icon": "https://avatars.githubusercontent.com/u/36074738?v=4",
+    "title": "SmithyNithy's Repository",
+    "index": 247
+  },
+  {
+    "url": "https://github.com/smoores-dev/storyteller-unraid",
+    "profile": "https://forums.unraid.net/profile/144985-smoores/",
+    "bio": "Creator and maintainer of Storyteller, a self-hosted platform for aligning ebooks and audiobooks.",
+    "icon": "https://gravatar.com/avatar/42222c68f7582de365c2a11603ebf9d3",
+    "DonateLink": "https://opencollective.com/storyteller",
+    "DonateText": "You can support future Storyteller development by donating through Open Collective!",
+    "title": "smoores' Repository",
+    "index": 248
+  },
+  {
+    "url": "https://github.com/Kometa-Team/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/198915-sohjiro/",
+    "bio": "Author of Kometa.",
+    "icon": "https://avatars.githubusercontent.com/u/166754869",
+    "DonateLink": "https://github.com/sponsors/meisnate12",
+    "DonateText": "Even the smallest donation from you will help keep Kometa updated with new fixes and features.",
+    "Reddit": "https://www.reddit.com/r/Kometa/",
+    "Forum": "https://github.com/Kometa-Team/Kometa/issues/new/choose",
+    "Discord": "https://kometa.wiki/en/latest/discord/",
+    "WebPage": "https://kometa.wiki",
+    "title": "Sohjiro's Repository",
+    "index": 249
+  },
+  {
+    "url": "https://github.com/soitora/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/282682-soitora/",
+    "bio": "I am adding Unraid Community Application templates for containers I have set up and not found in the Application store.",
+    "icon": "https://github.com/soitora.png",
+    "DonateLink": "https://ko-fi.com/soitora",
+    "DonateText": "If you like my work please consider Donating.",
+    "Forum": "https://forums.unraid.net/topic/192298-support-soitoras-unraid-templates/",
+    "title": "Soitora's Repository",
+    "index": 250
+  },
+  {
+    "url": "https://github.com/soonic6/unraid-templates-ca",
+    "profile": "https://forums.unraid.net/profile/94002-sonic6/",
+    "bio": "simple Unraid templates",
+    "icon": "https://raw.githubusercontent.com/soonic6/unraid-templates-ca/main/soonic6/images/image.png",
+    "title": "sonic6's Repository",
+    "index": 251
+  },
+  {
+    "url": "https://github.com/Squidly271/plugin-repository",
+    "profile": "https://forums.unraid.net/profile/10290-squid/",
+    "bio": "Unraid fan and the author and maintainer of various plugins for Unraid including **Community Applications** and **Fix Common Problems**, along with being a major contributor to the forums at large.  I am of the belief that plugins carry an extra burden of support due to their nature and will endeavor to fix any problems with them ASAP.  Occasionally sarcastic and always a twisted sense of humour.",
+    "icon": "https://github.com/Squidly271/community.applications/raw/master/webImages/1645994257.png",
+    "DonateLink": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7M7CBCVU732XG",
+    "DonateText": "Buy me a beer",
+    "Photo": "https://raw.githubusercontent.com/Squidly271/community.applications/master/webImages/20191221_193714.jpg",
+    "Video": "https://www.youtube.com/watch?v=WMxGVfk09lU",
+    "title": "Squid's Repository",
+    "index": 252
+  },
+  {
+    "url": "https://github.com/simonsickle/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/152551-ssickle/",
+    "bio": "Creating software that makes day to day life easier. Android engineer by trade.",
+    "icon": "https://avatars.githubusercontent.com/u/51972200",
+    "DonateLink": "https://cash.app/$ssickle",
+    "DonateText": "Buy me a beer / pizza",
+    "Forum": "https://github.com/simonsickle/unraid-templates/discussions/categories/q-a-support",
+    "Twitter": "https://twitter.com/ssickle42",
+    "Discord": "https://discord.gg/TnwYRPKg72",
+    "WebPage": "https://simonsickle.com/",
+    "title": "ssickle's Repository",
+    "index": 253
+  },
+  {
+    "url": "https://github.com/Staros-Labs/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294271-starosdev/",
+    "bio": "Unraid Community Applications templates for Scrutiny - Hard Drive S.M.A.R.T Monitoring.",
+    "icon": "https://raw.githubusercontent.com/Starosdev/scrutiny/master/webapp/frontend/src/assets/images/logo/scrutiny-logo-dark.png",
+    "title": "Starosdev's Repository",
+    "index": 254
+  },
+  {
+    "url": "https://github.com/StevenDTX/unraid-plugin-repository",
+    "profile": "https://forums.unraid.net/profile/778-stevend/",
+    "bio": "Been using Unraid since 2008. Running virtualized Unraid since about 2013.",
+    "icon": "https://raw.githubusercontent.com/StevenDTX/unraid-plugin-repository/master/stevendtx.png",
+    "title": "StevenD's Repository",
+    "index": 255
+  },
+  {
+    "url": "https://github.com/superboki/UNRAID-FR",
+    "profile": "https://forums.unraid.net/profile/92630-superboki/",
+    "bio": "Hi, it's superboki! Passionate about Unraid, I'm trying with my community to create tutorials accessible in French and English.",
+    "icon": "https://avatars.githubusercontent.com/u/105635291?s=400",
+    "DonateLink": "https://tipeee.com/superboki",
+    "DonateText": "If you want to encourage this work, please consider making a small donation on Tipeee.",
+    "Facebook": "https://www.facebook.com/superboki.yt",
+    "Twitter": "https://twitter.com/superboki",
+    "Discord": "https://discord.gg/CrK5eteSjK",
+    "WebPage": "https://youtube.com/superboki",
+    "title": "superboki's Repository",
+    "index": 256
+  },
+  {
+    "url": "https://github.com/its-sven/docker-templates",
+    "profile": "https://forums.unraid.net/profile/146810-sven-w%C3%BCrth/",
+    "bio": "\ud83d\udc68\u200d\ud83d\udcbbWana be IT-Guy\n     \ud83c\udfb6Musican\n     \ud83c\udf34Living in Saarland",
+    "icon": "https://raw.githubusercontent.com/its-sven/docker-templates/main/images/sven.jpg",
+    "DonateLink": "https://paypal.me/wuerthsven",
+    "DonateText": "One Coffee or for me \ud83e\udd7a\ud83d\udc49\ud83d\udc48",
+    "Discord": "https://discord.com/invite/2KRSV2arDN",
+    "WebPage": "https://svenw.de",
+    "title": "Sven W\u00fcrth's Repository",
+    "index": 257
+  },
+  {
+    "url": "https://github.com/swiss01/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/96834-swiss01/",
+    "bio": "Hobby developer. I hope you like my work",
+    "icon": "https://raw.githubusercontent.com/swiss01/unraid-templates/refs/heads/main/swiss01/images/Esel.png",
+    "DonateLink": "https://ko-fi.com/swiss01",
+    "DonateText": "If you like my work, you are welcome to donate something, but it is voluntary ;)",
+    "title": "swiss01's Repository",
+    "index": 258
+  },
+  {
+    "url": "https://github.com/sydlexius/unraid-templates",
+    "profile": null,
+    "bio": "Unraid Docker templates maintained by sydlexius. Support for each application is available via its GitHub Issues page.",
+    "icon": "https://raw.githubusercontent.com/sydlexius/unraid-templates/main/icon.svg",
+    "WebPage": "https://github.com/sydlexius",
+    "title": "sydlexius' Repository",
+    "index": 259
+  },
+  {
+    "url": "https://github.com/warwickschroeder/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/103842-syknight/",
+    "bio": "Long time user of Unraid. Software Engineer and Solution Architect by profession.",
+    "icon": "https://avatars.githubusercontent.com/u/7676501?v=4",
+    "title": "Syknight's Repository",
+    "index": 260
+  },
+  {
+    "url": "https://github.com/jason-bean/docker-templates",
+    "profile": "https://forums.unraid.net/profile/71020-taddeusz/",
+    "bio": "I create Docker containers that are of interest to me that I hope others find also find useful.",
+    "icon": "https://raw.githubusercontent.com/jason-bean/docker-templates/master/jasonbean-repo/me.jpeg",
+    "DonateLink": "https://paypal.me/jasonsbean/0usd",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Taddeusz' Repository",
+    "index": 261
+  },
+  {
+    "url": "https://github.com/Teknicallity/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/170368-teknicallity/",
+    "bio": "Amatuer Unraid enthusiast",
+    "icon": "https://raw.githubusercontent.com/Teknicallity/unraid-templates/main/images/pope-freeman.png",
+    "Reddit": "https://www.reddit.com/user/Teknicallity",
+    "WebPage": "https://github.com/Teknicallity",
+    "title": "Teknicallity's Repository",
+    "index": 262
+  },
+  {
+    "url": "https://github.com/terratrax/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/230036-terratrax/",
+    "bio": "General technologist and self-hoster.",
+    "icon": "https://s3.ultimus.cloud/ultimus-static/terratrax/terratrax.png",
+    "DonateLink": "https://www.paypal.me/terratrax",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "terratrax's Repository",
+    "index": 263
+  },
+  {
+    "url": "https://github.com/lando786/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/270787-thatguyorlando/",
+    "bio": "Developer, father, hobbyist.",
+    "icon": "https://avatars.githubusercontent.com/u/568133?v=4&size=64",
+    "DonateLink": "https://www.buymeacoffee.com/lando786",
+    "DonateText": "If you like my work please consider buying me a coffee.",
+    "WebPage": "https://luisdasta.com/",
+    "title": "ThatGuyOrlando's Repository",
+    "index": 264
+  },
+  {
+    "url": "https://github.com/brianmiller/docker-templates",
+    "profile": "https://forums.unraid.net/profile/86892-thebrian",
+    "bio": "Just a guy.",
+    "icon": "https://forums.unraid.net/uploads/monthly_2020_06/0.jpeg.8161bb3ec6c5a310f39f444ac280ce23.jpeg",
+    "title": "TheBrian's Repository",
+    "index": 265
+  },
+  {
+    "url": "https://github.com/thecode/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/109528-thecode/",
+    "bio": "I like to contribute to projects that I use in order to make them better",
+    "icon": "https://raw.githubusercontent.com/thecode/unraid-docker-templates/main/icons/thecode.jpg",
+    "DonateLink": "https://paypal.me/levyshay",
+    "DonateText": "If you like my work please consider Donating.",
+    "Facebook": "https://www.facebook.com/levyshay/",
+    "Twitter": "https://twitter.com/intent/follow?screen_name=le1vyshay",
+    "Discord": "https://discordapp.com/users/713107876390109225/",
+    "WebPage": "https://github.com/thecode",
+    "title": "thecode's Repository",
+    "index": 266
+  },
+  {
+    "url": "https://github.com/theweebcoders/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/146571-tim000x3/",
+    "bio": "We are weebs who code. Everything we make here is free.",
+    "icon": "https://avatars.githubusercontent.com/u/172365950?s=400&u=7a2a1b390dff7240cfc5a662414c90d19eef7217&v=4",
+    "DonateLink": "https://www.buymeacoffee.com/tim000x3",
+    "DonateText": "If you like our work please consider Donating.",
+    "Discord": "https://discord.gg/S7NcUdhKRD",
+    "title": "tim000x3's Repository",
+    "index": 267
+  },
+  {
+    "url": "https://github.com/tipdec-siblyn/Urbit-on-Unraid",
+    "profile": "https://forums.unraid.net/profile/158043-tipdec-siblyn/",
+    "bio": "Hi, I create template for self-host app I love. New app and video guide soon ;) You can reach me on urbit: ~tipdec-siblyn",
+    "icon": "https://raw.githubusercontent.com/tipdec-siblyn/unraid-template/main/avatar.jpg",
+    "DonateLink": "https://github.com/tipdec-siblyn/unraid-template/blob/main/DONATION.md",
+    "DonateText": "If you like my work please consider Donating. (BTC only)",
+    "title": "tipdec-sbilyn's Repository",
+    "index": 268
+  },
+  {
+    "url": "https://github.com/titandrive/yarnl-unraid",
+    "profile": "https://forums.unraid.net/profile/294252-titandrive/",
+    "bio": "Developer of Yarnl, a self-hosted crochet pattern manager. Aficionado of crocheting and self-hosting. Source code is available on GitHub at github.com/titandrive/yarnl.",
+    "icon": "https://raw.githubusercontent.com/titandrive/yarnl-unraid/main/icon.png",
+    "DonateLink": "https://ko-fi.com/titandrive",
+    "DonateText": "If you enjoy my work please consider supporting me on Ko-fi.",
+    "Forum": "https://forums.unraid.net/topic/197409-support-titandriveyarnl/",
+    "WebPage": "https://yarnl.com",
+    "title": "titandrive's Repository",
+    "index": 269
+  },
+  {
+    "url": "https://github.com/tmchow/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/69431-tmchow/",
+    "bio": "Creating Docker containers for fun.",
+    "icon": "https://raw.githubusercontent.com/tmchow/unraid-docker-templates/master/img/avatar.jpg",
+    "title": "tmchow's Repository",
+    "index": 270
+  },
+  {
+    "url": "https://github.com/tquizzle/Docker-xml",
+    "profile": "https://forums.unraid.net/profile/13228-tq/",
+    "bio": "Just a guy who loves containers and Unraid!",
+    "icon": "https://raw.githubusercontent.com/tquizzle/Docker-xml/refs/heads/master/img/412380.png",
+    "DonateLink": "https://ko-fi.com/tquinnelly",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://github.com/tquizzle",
+    "title": "TQ's Repository",
+    "index": 271
+  },
+  {
+    "url": "https://github.com/transmute-app/unraid-template",
+    "profile": "https://forums.unraid.net/profile/294904-chase-roohms/",
+    "bio": "Transmute is a free, open source, self-hosted file converter built for privacy and automation. Convert images, video, audio, documents, spreadsheets, subtitles, and fonts entirely locally, with no file size limits and no third-party access to your files. For support, visit the GitHub Issues page.",
+    "icon": "https://raw.githubusercontent.com/transmute-app/transmute/refs/heads/main/assets/brand/beaker-red-bg.png",
+    "WebPage": "https://transmute.sh",
+    "title": "Transmute's Repository",
+    "index": 272
+  },
+  {
+    "url": "https://github.com/tubearchivist/unraid-templates",
+    "profile": null,
+    "bio": "Your selfhosted YouTube media server!",
+    "icon": "https://raw.githubusercontent.com/tubearchivist/unraid-templates/main/TubeArchivist_Logo.png",
+    "DonateLink": "https://github.com/tubearchivist/tubearchivist#donate",
+    "DonateText": "If you find this project useful, please consider Donating.",
+    "Discord": "https://www.tubearchivist.com/discord",
+    "WebPage": "https://www.tubearchivist.com/",
+    "title": "TubeArchivist's Official Repository",
+    "index": 273
+  },
+  {
+    "url": "https://github.com/Unknowncall/adsb-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/206238-unknowncall/",
+    "bio": "Creating docker templates for Unraid! Please let me know if you want additional templates.",
+    "icon": "https://avatars.githubusercontent.com/u/8108400?v=4",
+    "title": "Unknowncall's Repository",
+    "index": 274
+  },
+  {
+    "url": "https://github.com/Reaparr/Unraid-CA-Templates",
+    "profile": "https://forums.unraid.net/profile/102645-unmax/",
+    "bio": "Currently working hard on developing Reaparr! Let me know if you have any ideas or feedback on how to make it even more awesome!",
+    "icon": "https://avatars.githubusercontent.com/u/15127381",
+    "DonateLink": "https://github.com/sponsors/JasonLandbridge",
+    "DonateText": "Consider throwing money at me to get all your wishes granted!",
+    "WebPage": "https://github.com/JasonLandbridge",
+    "title": "Unmax's Repository",
+    "index": 275
+  },
+  {
+    "url": "https://github.com/UNRA1DUser/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/120631-unra1duser/",
+    "bio": "I am trying to create Docker containers with official images. I create the template as modular as possible so that almost all settings can be set.",
+    "icon": "https://raw.githubusercontent.com/UNRA1DUser/unraid-docker-templates/main/templates/img/avatar.png",
+    "DonateLink": "https://www.paypal.com/paypalme/M4rc31",
+    "DonateText": "If you like my work and would like to support me please consider Donating.",
+    "WebPage": "https://github.com/UNRA1DUser/unraid-docker-templates",
+    "title": "UNRA1DUser's Repository",
+    "index": 276
+  },
+  {
+    "url": "https://github.com/VandaLpr/unRAID-CA-templates",
+    "profile": null,
+    "bio": "A bunch of happy folks adding what the community want, to give them choice, for free. Request stuff on our github https://github.com/selfhosters/Unraid-CA-templates",
+    "icon": "https://github.com/selfhosters.png",
+    "Forum": "https://forums.unraid.net/topic/87798-support-selfhostersnets-template-repository/",
+    "Discord": "https://discord.gg/qWPbc8R",
+    "WebPage": "https://selfhosters.net/",
+    "title": "VandaL Repository",
+    "index": 277
+  },
+  {
+    "url": "https://github.com/vinid223/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/91081-vinid223",
+    "bio": "Creating Docker containers for my needs and sharing them with the community.",
+    "icon": "https://raw.githubusercontent.com/vinid223/unraid-docker-templates/master/vinid223/images/avatar.png",
+    "DonateLink": "https://paypal.me/vinid223",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "vinid223's Repository",
+    "index": 278
+  },
+  {
+    "url": "https://github.com/VladoPortos/vladoportos-unraid-xml",
+    "profile": "https://forums.unraid.net/profile/103082-vladoportos/",
+    "bio": "Trying my best to maintain Folder.View2 and SkillGoblin.",
+    "icon": "https://raw.githubusercontent.com/VladoPortos/vladoportos-unraid-xml/master/img/avatar.png",
+    "DonateLink": "https://ko-fi.com/vladoportos",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://skillgoblin.com",
+    "title": "VladoPortos' Repository",
+    "index": 279
+  },
+  {
+    "url": "https://github.com/vrx-666/unraid-xml",
+    "profile": "https://forums.unraid.net/profile/128590-vrx/",
+    "bio": "Creating Docker containers for fun. Most often for my own needs, which are not met by other available in CA.",
+    "icon": "https://raw.githubusercontent.com/vrx-666/unraid-xml/master/img/mask.jpg",
+    "title": "vrx's Repository",
+    "index": 280
+  },
+  {
+    "url": "https://github.com/TorBox-App/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/247536-wamy/",
+    "bio": "Official TorBox CA Profile for TorBox Docker Apps on Unraid!",
+    "icon": "https://torbox.app/logo.png",
+    "DonateLink": "https://torbox.app/subscription",
+    "DonateText": "To use these images to their full capacity, get a paid TorBox account here.",
+    "Reddit": "https://join-reddit.torbox.app",
+    "Twitter": "https://x.com/torbox_app",
+    "Discord": "https://join-discord.torbox.app",
+    "WebPage": "https://torbox.app",
+    "title": "Wamy's Repository",
+    "index": 281
+  },
+  {
+    "url": "https://github.com/Waseh/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/5193-waseh/",
+    "bio": "Maintaining a plugin which installs rclone on your Unraid machine.",
+    "icon": "https://raw.githubusercontent.com/Waseh/unraidtemplates/master/WasehLogo.png",
+    "DonateLink": "https://paypal.me/WasehDev",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Waseh's Repository",
+    "index": 282
+  },
+  {
+    "url": "https://github.com/itsnotwebby/unraid-templates",
+    "profile": null,
+    "bio": "Kind of a big deal. <3 Unraid",
+    "icon": "https://raw.githubusercontent.com/itsnotwebby/unraid-templates/main/webby.png",
+    "WebPage": "https://github.com/itsnotwebby",
+    "title": "Webby's Repository",
+    "index": 283
+  },
+  {
+    "url": "https://github.com/W3LFARe/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/129748-welfare/",
+    "bio": "Just Making templates and containers for things I find interesting. <3 Unraid",
+    "icon": "https://raw.githubusercontent.com/W3LFARe/unraid_templates/main/WELFARE.png",
+    "DonateLink": "https://ko-fi.com/w3lfare",
+    "DonateText": "",
+    "WebPage": "https://github.com/W3LFARe",
+    "title": "welfare's Repository",
+    "index": 284
+  },
+  {
+    "url": "https://github.com/Womabre/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/90075-womabre",
+    "bio": "Creator and maintainer of the iCloudPD Docker template.",
+    "icon": "https://raw.githubusercontent.com/Womabre/unraid-docker-templates/master/images/132746.jpg",
+    "DonateLink": "https://paypal.me/wmbreedveld",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Womabre's Repository",
+    "index": 285
+  },
+  {
+    "url": "https://github.com/wupasscat/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/103746-wupasscat/",
+    "bio": "https://github.com/wupasscat/Unraid-templates",
+    "icon": "https://raw.githubusercontent.com/wupasscat/wupasscat/main/profile.png",
+    "DonateLink": "https://www.buymeacoffee.com/wupasscat",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "wupasscat's Repository",
+    "index": 286
+  },
+  {
+    "url": "https://github.com/xthursdayx/docker-templates",
+    "profile": "https://forums.unraid.net/profile/69067-zandrsn/",
+    "bio": "I maintain a number of Docker images based on Debian, Ubuntu and Alpine Linux, with the goal of producing simple, stable and user-friendly containers. I also create templates for Unraid users.",
+    "icon": "https://raw.githubusercontent.com/xthursdayx/docker-templates/master/xthursdayx/images/xthursdayx.png",
+    "DonateLink": "https://www.buymeacoffee.com/xthursdayx",
+    "DonateText": "If you appreciate my work please consider buying me a coffee, cheers!",
+    "Forum": "https://forums.unraid.net/topic/88410-support-xthursdayx-unraid-docker-templates/",
+    "title": "xthursdayx's Repository",
+    "index": 287
+  },
+  {
+    "url": "https://github.com/xWeegix/templates",
+    "profile": "https://forums.unraid.net/profile/132338-xweegix/",
+    "bio": "Adding templates for cool projects. Please support the authors and contributors.",
+    "icon": "https://github.com/xWeegix.png",
+    "title": "xWeegix's Repository",
+    "index": 288
+  },
+  {
+    "url": "https://gitlab.com/yayitazale/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/88392-yayitazale/",
+    "bio": "Creating Docker templates for personal projects",
+    "icon": "https://github.com/yayitazale.png",
+    "DonateLink": "https://paypal.me/JosebaEgiaLarrinaga",
+    "DonateText": "If you like my work please consider Donating.",
+    "WebPage": "https://firstcommit.dev/",
+    "title": "yayitazale's Repository",
+    "index": 289
+  },
+  {
+    "url": "https://github.com/Yoruio/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/126098-yoruio/",
+    "bio": "Mostly just templates of my containers, but stay tuned for more?",
+    "icon": "https://avatars.githubusercontent.com/u/38411921",
+    "DonateLink": "https://www.paypal.com/donate/?hosted_button_id=R44M45FYUVUDJ",
+    "DonateText": "Help me through life with a shot or two of age-appropriate beverage!",
+    "title": "Yoruio's Repository",
+    "index": 290
+  },
+  {
+    "url": "https://github.com/Yusseiin/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/279816-yusseiin/",
+    "bio": "I create Docker applications with one main goal: making life easier for the user. My containers are designed to work out of the box, stay up to date automatically, and require as little manual setup as possible\u2014so you can focus on using the app, not maintaining it.",
+    "icon": "https://raw.githubusercontent.com/yusseiin/unraid-templates/main/img/avatar.jpg",
+    "DonateLink": "https://www.paypal.com/paypalme/yusseiin",
+    "DonateText": "If you like my work please consider Donating.",
+    "title": "Yusseiin's Repository",
+    "index": 291
+  },
+  {
+    "url": "https://github.com/devzwf/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/119200-zappyzap/",
+    "bio": "Noname dude making some template to help.",
+    "icon": "https://raw.githubusercontent.com/devzwf/unraid-docker-templates/main/images/Nutz.jpg",
+    "DonateLink": "https://ko-fi.com/devzwf",
+    "DonateText": "Don't donate to me! Instead, please donate the creators of the apps, but if you insist",
+    "title": "ZappyZap's Repository",
+    "index": 292
+  },
+  {
+    "url": "https://github.com/zgorizzo69/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119851-zgo/",
+    "bio": "All about decentralization.",
+    "icon": "https://github.com/zgorizzo69.png",
+    "title": "zgo's Repository",
+    "index": 293
+  },
+  {
+    "url": "https://github.com/vertex-app/docker-template",
+    "profile": "https://forums.unraid.net/profile/171336-%E6%A0%97%E5%B1%B1%E6%9C%AA%E6%9D%A5/",
+    "bio": "Good Luck!",
+    "icon": "https://pic.lswl.in/images/2021/12/07/8362b5b3fe8744e0f3bfa93f1105857d.jpg",
+    "title": "\u6817\u5c71\u672a\u6765 Repository",
+    "index": 294
+  },
+  {
+    "url": "https://github.com/7oasty/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/189568-7oasty/",
+    "title": "7oasty's Repository",
+    "index": 295
+  },
+  {
+    "url": "https://github.com/ahmedbadr3/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294773-abadr/",
+    "title": "abadr's Repository",
+    "index": 296
+  },
+  {
+    "url": "https://github.com/drewzh/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/266696-abreast-statesman5405/",
+    "title": "abreast-statesman5405's Repository",
+    "index": 297
+  },
+  {
+    "url": "https://github.com/Watso4183/Unraid",
+    "profile": "https://forums.unraid.net/profile/293586-acmepluto/",
+    "title": "AcmePluto's Repository",
+    "index": 298
+  },
+  {
+    "url": "https://github.com/aeleos/cloudflared",
+    "profile": "https://forums.unraid.net/profile/78732-aeleos/",
+    "title": "aeleos' Repository",
+    "index": 299
+  },
+  {
+    "url": "https://github.com/afairgiant/MediKeep_unraid",
+    "profile": "https://forums.unraid.net/profile/116260-afairgiant/",
+    "title": "afairgiant's Repository",
+    "index": 300
+  },
+  {
+    "url": "https://github.com/wbynum/docker-templates",
+    "profile": "https://forums.unraid.net/profile/97630-aggie1999/",
+    "title": "Aggie1999's Repository",
+    "index": 301
+  },
+  {
+    "url": "https://github.com/ajb3932/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/276974-ajb3932/",
+    "title": "ajb3932's Repository",
+    "index": 302
+  },
+  {
+    "url": "https://github.com/alexbn71/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169325-alexbn71/",
+    "title": "alexbn71's Repository",
+    "index": 303
+  },
+  {
+    "url": "https://github.com/AlexGreenUK/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/116574-alexgreenuk/",
+    "title": "AlexGreenUK's Repository",
+    "index": 304
+  },
+  {
+    "url": "https://github.com/allaboutduncan/clu-comics",
+    "profile": null,
+    "DonateLink": "https://www.buymeacoffee.com/allaboutduncan",
+    "DonateText": "Buy me a coffee",
+    "title": "AllAboutDuncan's Repository",
+    "index": 305
+  },
+  {
+    "url": "https://github.com/evilalmus/UNRAID_COMMUNITY_APPS",
+    "profile": "https://forums.unraid.net/profile/178171-almus/",
+    "title": "almus' Repository",
+    "index": 306
+  },
+  {
+    "url": "https://github.com/alyssaholland99/unraid-immich-tiktok-remover",
+    "profile": "https://forums.unraid.net/profile/289132-alyssaholland/",
+    "title": "AlyssaHolland's Repository",
+    "index": 307
+  },
+  {
+    "url": "https://github.com/anojht/invoiceninja",
+    "profile": "https://forums.unraid.net/profile/87757-microservices/",
+    "title": "anojht's Repository",
+    "index": 308
+  },
+  {
+    "url": "https://github.com/anym001/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/119296-anym001/",
+    "title": "Anym001's Repository",
+    "index": 309
+  },
+  {
+    "url": "https://github.com/AradD7/lightarr-template-files",
+    "profile": "https://forums.unraid.net/profile/293896-arad",
+    "title": "Arad's Repository",
+    "index": 310
+  },
+  {
+    "url": "https://github.com/argash/amongusdiscord_unraid",
+    "profile": "https://forums.unraid.net/profile/112259-argash/",
+    "title": "argash's Repository",
+    "index": 311
+  },
+  {
+    "url": "https://github.com/AronMarinelli/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/126179-aronm/",
+    "title": "AronM's Repository",
+    "index": 312
+  },
+  {
+    "url": "https://github.com/asparon/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/96069-asparon/",
+    "title": "Asparon's Repository",
+    "index": 313
+  },
+  {
+    "url": "https://github.com/atribe/unRAID-docker",
+    "profile": "https://forums.unraid.net/profile/70671-atribe/",
+    "title": "atribe's Repository",
+    "index": 314
+  },
+  {
+    "url": "https://github.com/b42n1/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/167912-b4rny/",
+    "title": "B4rny's Repository",
+    "index": 315
+  },
+  {
+    "url": "https://github.com/BBergle/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/228849-bbergle/",
+    "title": "BBergle's Repository",
+    "index": 316
+  },
+  {
+    "url": "https://github.com/benderstwin/docker-templates",
+    "profile": "https://forums.unraid.net/profile/11326-bryanwirth/",
+    "title": "Bender's Repository",
+    "index": 317
+  },
+  {
+    "url": "https://github.com/gbendy/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/275025-bendy/",
+    "title": "bendy's Repository",
+    "index": 318
+  },
+  {
+    "url": "https://github.com/bert-mccutchen/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/178618-bert-mccutchen/",
+    "title": "Bert McCutchen's Repository",
+    "index": 319
+  },
+  {
+    "url": "https://github.com/bfox135/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/174793-bfox135/",
+    "title": "Bfox135's Repository",
+    "index": 320
+  },
+  {
+    "url": "https://github.com/bghizzy/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/268319-bg_hizzy/",
+    "title": "bg_hizzy's Repository",
+    "index": 321
+  },
+  {
+    "url": "https://github.com/BryanGoble/docker-templates",
+    "profile": "https://forums.unraid.net/profile/290235-bgubs/",
+    "title": "bgubs' Repository",
+    "index": 322
+  },
+  {
+    "url": "https://github.com/BigManDave/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/133103-bigmandave/",
+    "title": "BigManDave's Repository",
+    "index": 323
+  },
+  {
+    "url": "https://github.com/bigsing/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/7676-bigsing/",
+    "title": "bigsing's Repository",
+    "index": 324
+  },
+  {
+    "url": "https://github.com/Billyboii/mcsmanager-unraid",
+    "profile": "https://forums.unraid.net/profile/293091-billyboi/",
+    "title": "billyboi's Repository",
+    "index": 325
+  },
+  {
+    "url": "https://github.com/bitcryptic-gw/unraid-pi-network-node",
+    "profile": "https://forums.unraid.net/profile/287583-bitcryptic/",
+    "title": "BitCryptic's Repository",
+    "index": 326
+  },
+  {
+    "url": "https://github.com/BitlessByte0/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/261347-bitlessbyte/",
+    "title": "BitlessByte's Repository",
+    "index": 327
+  },
+  {
+    "url": "https://github.com/TheBlackBush/bambulab_metrics_exporter",
+    "profile": "https://forums.unraid.net/profile/119627-blackbush/",
+    "title": "BlackBush's Repository",
+    "index": 328
+  },
+  {
+    "url": "https://github.com/kclif9/Unraid_Templates",
+    "profile": "https://forums.unraid.net/profile/279194-bluelamp3445/",
+    "title": "blue.lamp3445's Repository",
+    "index": 329
+  },
+  {
+    "url": "https://github.com/bluegizmo83/DockerXMLs",
+    "profile": "https://forums.unraid.net/profile/105585-bluegizmo83",
+    "title": "bluegizmo83's Repository",
+    "index": 330
+  },
+  {
+    "url": "https://github.com/bmartino1/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/118010-bmartino1/",
+    "title": "bmartino1's Repository",
+    "index": 331
+  },
+  {
+    "url": "https://github.com/bobbintb/docker-templates",
+    "profile": "https://forums.unraid.net/profile/550-bobbintb/",
+    "title": "bobbintb's Repository",
+    "index": 332
+  },
+  {
+    "url": "https://github.com/StuffAnThings/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/76370-bobokun/",
+    "title": "bobokun's Repository",
+    "index": 333
+  },
+  {
+    "url": "https://github.com/Bobstin/willow-application-server",
+    "profile": "https://forums.unraid.net/profile/227361-bobstin/",
+    "title": "Bobstin's Repository",
+    "index": 334
+  },
+  {
+    "url": "https://github.com/bonedrums/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/72855-bonedrums/",
+    "title": "bonedrums' Repository",
+    "index": 335
+  },
+  {
+    "url": "https://github.com/olilanz/unraid-templates/",
+    "profile": "https://forums.unraid.net/profile/175858-boomshakalaka/",
+    "title": "boomshakala's Repository",
+    "index": 336
+  },
+  {
+    "url": "https://github.com/botmem/botmem",
+    "profile": null,
+    "title": "botmem",
+    "index": 337
+  },
+  {
+    "url": "https://github.com/Bovive/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/259292-bovive/",
+    "title": "Bovive's Repository",
+    "index": 338
+  },
+  {
+    "url": "https://github.com/breadlysm/Breads-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/84220-breadlysm/",
+    "title": "breadlysm's Repository",
+    "index": 339
+  },
+  {
+    "url": "https://github.com/brettm357/docker-templates",
+    "profile": "https://forums.unraid.net/profile/62222-brettm357/",
+    "title": "brettm357's Repository",
+    "index": 340
+  },
+  {
+    "url": "https://github.com/brq-ae/boltarr-templates",
+    "profile": null,
+    "title": "Brq.ae Repository",
+    "index": 341
+  },
+  {
+    "url": "https://github.com/brycelarge/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/112270-brycelarge/",
+    "title": "brycelarge's Repository",
+    "index": 342
+  },
+  {
+    "url": "https://github.com/bubba925/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/189614-bubbadrk/",
+    "title": "bubba925's Repository",
+    "index": 343
+  },
+  {
+    "url": "https://github.com/emaspa/emaspa-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/71014-bubbl3/",
+    "title": "bubbl3's Repository",
+    "index": 344
+  },
+  {
+    "url": "https://github.com/FrankM77/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/153626-built2succeed/",
+    "title": "Built2Succeed's Repository",
+    "index": 345
+  },
+  {
+    "url": "https://github.com/jshridha/templates",
+    "profile": "https://forums.unraid.net/profile/7061-bungy/",
+    "title": "Bungy's Repository",
+    "index": 346
+  },
+  {
+    "url": "https://github.com/buxxdev/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/291279-mbxy/",
+    "title": "buxxdev's Repository",
+    "index": 347
+  },
+  {
+    "url": "https://github.com/Belstrekkie/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/224258-bversluis/",
+    "title": "BVersluis' Repository",
+    "index": 348
+  },
+  {
+    "url": "https://github.com/C3004/Unraid-Templates-C3004",
+    "profile": "https://forums.unraid.net/profile/142775-c3004/",
+    "title": "C3004's Repository",
+    "index": 349
+  },
+  {
+    "url": "https://github.com/C4ArtZ/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/106324-c4artz/",
+    "title": "c4artz' Repository",
+    "index": 350
+  },
+  {
+    "url": "https://github.com/cabi24/notenregal",
+    "profile": null,
+    "title": "cabi24's Repository",
+    "index": 351
+  },
+  {
+    "url": "https://github.com/cajuncoding/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/134398-cajuncoding/",
+    "title": "CajunCoding's Repository",
+    "index": 352
+  },
+  {
+    "url": "https://github.com/Camc314/unraid-jellyfin-vue",
+    "profile": "https://forums.unraid.net/profile/123309-camc314/",
+    "title": "Camc314's Repository",
+    "index": 353
+  },
+  {
+    "url": "https://github.com/cameron581/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/253440-cameron581/",
+    "title": "Cameron581's Repository",
+    "index": 354
+  },
+  {
+    "url": "https://github.com/TheMapledCog/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/168586-campu0999/",
+    "title": "campu0999's Repository",
+    "index": 355
+  },
+  {
+    "url": "https://github.com/P3R-CO/unraid",
+    "profile": "https://forums.unraid.net/profile/106374-captasic/",
+    "title": "capt.asic's Repository",
+    "index": 356
+  },
+  {
+    "url": "https://github.com/CaptainPimpJr/Unraid-Community-Applications",
+    "profile": "https://forums.unraid.net/profile/271177-cptpimpjunior/",
+    "title": "CaptainPimpJr's Repository",
+    "index": 357
+  },
+  {
+    "url": "https://github.com/carrotwaxr/peek-stash-browser",
+    "profile": "https://forums.unraid.net/profile/291876-carrot-waxxr/",
+    "title": "Carrot Waxxr's Repository",
+    "index": 358
+  },
+  {
+    "url": "https://github.com/chacawaca/post-recording-xml",
+    "profile": "https://forums.unraid.net/profile/111526-chacawaca",
+    "title": "Chacawaca's Repository",
+    "index": 359
+  },
+  {
+    "url": "https://github.com/PotentialIngenuity/petio-unraid",
+    "profile": "https://forums.unraid.net/profile/107700-chargingcosmonaut/",
+    "title": "ChargingCosmonaut's Repository",
+    "index": 360
+  },
+  {
+    "url": "https://github.com/Maximize1107/unRAID-Templates",
+    "profile": "https://forums.unraid.net/profile/136631-chrislb/",
+    "title": "chrislb's Repository",
+    "index": 361
+  },
+  {
+    "url": "https://github.com/ciegg/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/155366-cieg/",
+    "title": "cieg's Repository",
+    "index": 362
+  },
+  {
+    "url": "https://github.com/ckocyigit/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/110566-ck98/",
+    "title": "CK98's Repository",
+    "index": 363
+  },
+  {
+    "url": "https://github.com/clowrym/docker-templates",
+    "profile": "https://forums.unraid.net/profile/26570-clowrym/",
+    "title": "clowrym's Repository",
+    "index": 364
+  },
+  {
+    "url": "https://github.com/Adidasdaniel98/RepetierDocker",
+    "profile": "https://forums.unraid.net/profile/120747-codeluxe/",
+    "title": "Codeluxe's Repository",
+    "index": 365
+  },
+  {
+    "url": "https://github.com/coppit/docker-templates",
+    "profile": "https://forums.unraid.net/profile/167-coppit/",
+    "title": "coppit's Repository",
+    "index": 366
+  },
+  {
+    "url": "https://github.com/CordlessWool/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/289062-cordlesswool/",
+    "title": "CordlessWool's Repository",
+    "index": 367
+  },
+  {
+    "url": "https://github.com/criscrafter/Unraid-CA",
+    "profile": "https://forums.unraid.net/profile/154961-criscrafter/",
+    "title": "criscrafter's Repository",
+    "index": 368
+  },
+  {
+    "url": "https://github.com/pairofcrocs/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/98010-crocs/",
+    "title": "Croc's Repository",
+    "index": 369
+  },
+  {
+    "url": "https://github.com/NickM-27/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/128178-crzynik/",
+    "title": "crzynik's Repository",
+    "index": 370
+  },
+  {
+    "url": "https://github.com/cschanot/docker-templates",
+    "profile": "https://forums.unraid.net/profile/80091-cschanot/",
+    "title": "cschanot's Repository",
+    "index": 371
+  },
+  {
+    "url": "https://github.com/glauth/unraid-glauth",
+    "profile": "https://forums.unraid.net/profile/111590-cyansmoker/",
+    "title": "cyansmoker's Repository",
+    "index": 372
+  },
+  {
+    "url": "https://github.com/CyaOnDaNet/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/100638-cyaondanet/",
+    "title": "CyaOnDaNet's Repository",
+    "index": 373
+  },
+  {
+    "url": "https://github.com/D34DC3N73R/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/101684-d34dc3n73r/",
+    "title": "D34DC3N73R's Repository",
+    "index": 374
+  },
+  {
+    "url": "https://github.com/d8ahazard/unraid-repository",
+    "profile": null,
+    "title": "d8ahazard's Repository",
+    "index": 375
+  },
+  {
+    "url": "https://github.com/d8sychain/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/72950-d8sychain/",
+    "title": "d8sychain's Repository",
+    "index": 376
+  },
+  {
+    "url": "https://github.com/knilix/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/126551-da-do-ron/",
+    "title": "da do ron's Repository",
+    "index": 377
+  },
+  {
+    "url": "https://github.com/daman20/ca-xmls",
+    "profile": "https://forums.unraid.net/profile/122785-daman12/",
+    "title": "daman12's Repository",
+    "index": 378
+  },
+  {
+    "url": "https://github.com/damongolding/immich-kiosk-unraid",
+    "profile": "https://forums.unraid.net/profile/285555-damongolding/",
+    "title": "DamonGolding's Repository",
+    "index": 379
+  },
+  {
+    "url": "https://github.com/DanRegalia/UNRAID",
+    "profile": "https://forums.unraid.net/profile/103107-danregalia/",
+    "title": "DanRegalia's Repository",
+    "index": 380
+  },
+  {
+    "url": "https://github.com/daredoes/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/157186-daredoes/",
+    "title": "daredoes' Repository",
+    "index": 381
+  },
+  {
+    "url": "https://github.com/jcesclapez/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/280038-darklesc/",
+    "title": "Darklesc's Repository",
+    "index": 382
+  },
+  {
+    "url": "https://github.com/Darkside138/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/166210-darkside138/",
+    "title": "Darkside138's Repository",
+    "index": 383
+  },
+  {
+    "url": "https://github.com/DavidSpek/homelablabelmaker",
+    "profile": "https://forums.unraid.net/profile/96461-davidspek/",
+    "title": "DavidSpek's 2nd Repository",
+    "index": 384
+  },
+  {
+    "url": "https://github.com/DavidSpek/unraid_docker_templates",
+    "profile": "https://forums.unraid.net/profile/96461-davidspek",
+    "title": "DavidSpek's Repository",
+    "index": 385
+  },
+  {
+    "url": "https://github.com/fdm-monster/fdm-monster-unraid",
+    "profile": "https://forums.unraid.net/profile/124887-davidzwa/",
+    "title": "davidzwa's Repository",
+    "index": 386
+  },
+  {
+    "url": "https://github.com/freeskier93/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/125013-dcooper/",
+    "title": "dcooper's Repository",
+    "index": 387
+  },
+  {
+    "url": "https://github.com/eulaly/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/99159-dealbakerjones/",
+    "title": "dealbakerjones' Repository",
+    "index": 388
+  },
+  {
+    "url": "https://github.com/DearTanker/Unraid-Docker-Template",
+    "profile": "https://forums.unraid.net/profile/98483-deartanker/",
+    "title": "DearTanker's Repository",
+    "index": 389
+  },
+  {
+    "url": "https://github.com/kurrier-org/kurrier",
+    "profile": "https://forums.unraid.net/profile/292187-debuggy12/",
+    "title": "debuggy12's Repository",
+    "index": 390
+  },
+  {
+    "url": "https://github.com/dereckhall/unraid-plugin-templates",
+    "profile": "https://forums.unraid.net/profile/294777-dereck/",
+    "title": "Dereck's Repository",
+    "index": 391
+  },
+  {
+    "url": "https://github.com/dervish666/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/179627-dervish/",
+    "title": "dervish's Repository",
+    "index": 392
+  },
+  {
+    "url": "https://github.com/DevlinDelFuego/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/287879-devlindelfuego/",
+    "title": "DevlinDelFuego's Repository",
+    "index": 393
+  },
+  {
+    "url": "https://github.com/chirmstream/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/103420-dglb99/",
+    "title": "dglb99's Repository",
+    "index": 394
+  },
+  {
+    "url": "https://github.com/dgongut/UnRAID-Templates",
+    "profile": "https://forums.unraid.net/profile/250140-dgongut/",
+    "title": "dgongut's Repository",
+    "index": 395
+  },
+  {
+    "url": "https://github.com/dhruvinsh/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/146712-dhruvin/",
+    "title": "Dhruvin's Repository",
+    "index": 396
+  },
+  {
+    "url": "https://github.com/quimnut/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/15731-dibbz/",
+    "title": "dibbz' Repository",
+    "index": 397
+  },
+  {
+    "url": "https://github.com/Dimtar/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/7694-dimtar/",
+    "title": "dimtar's Repository",
+    "index": 398
+  },
+  {
+    "url": "https://github.com/wandercone/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/116223-discoverit/",
+    "title": "DiscoverIT's Repository",
+    "index": 399
+  },
+  {
+    "url": "https://github.com/piranha771/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/159409-divid/",
+    "title": "Divid's Repository",
+    "index": 400
+  },
+  {
+    "url": "https://github.com/dixtdf/templates",
+    "profile": "https://forums.unraid.net/profile/262846-dixtdf/",
+    "title": "dixtdf's Repository",
+    "index": 401
+  },
+  {
+    "url": "https://github.com/DJ3vil/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/178613-dj3vil/",
+    "title": "DJ3vil's Repository",
+    "index": 402
+  },
+  {
+    "url": "https://github.com/dmacias72/unRAID-CA",
+    "profile": "https://forums.unraid.net/profile/11874-dmacias/",
+    "title": "dmacias' Repository",
+    "index": 403
+  },
+  {
+    "url": "https://github.com/docgyver/unraid-v6-plugins",
+    "profile": "https://forums.unraid.net/profile/21303-docgyver/",
+    "title": "docgyver's Repository",
+    "index": 404
+  },
+  {
+    "url": "https://github.com/doron1/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/8006-doron/",
+    "title": "doron's Repository",
+    "index": 405
+  },
+  {
+    "url": "https://github.com/ltdstudio/MoviePilot_unraid_CA",
+    "profile": "https://forums.unraid.net/profile/284198-doudou1234/",
+    "title": "doudou1234's Repository",
+    "index": 406
+  },
+  {
+    "url": "https://github.com/Drazzilb08/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/63966-drazzilb/",
+    "title": "Drazzilb's Repository",
+    "index": 407
+  },
+  {
+    "url": "https://github.com/davemachado/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/291782-drm8/",
+    "title": "drm's Repository",
+    "index": 408
+  },
+  {
+    "url": "https://github.com/drohack/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/275784-drohack/",
+    "title": "drohack's Repository",
+    "index": 409
+  },
+  {
+    "url": "https://github.com/Droppisalt/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/229261-droppisalt/",
+    "title": "Droppisalt's Repository",
+    "index": 410
+  },
+  {
+    "url": "https://github.com/Polemus/Unraid",
+    "profile": "https://forums.unraid.net/profile/140455-dusty-roberts/",
+    "title": "Dusty Roberts' Repository",
+    "index": 411
+  },
+  {
+    "url": "https://github.com/lomorage/unraid-template",
+    "profile": "https://forums.unraid.net/profile/138957-dwebf/",
+    "title": "DwebF's Repository",
+    "index": 412
+  },
+  {
+    "url": "https://github.com/unraid/dynamix-plugins-xml",
+    "profile": "https://forums.unraid.net/profile/2736-bonienl/",
+    "title": "Dynamix Plugin Repository",
+    "index": 413
+  },
+  {
+    "url": "https://github.com/DyonR/docker-templates",
+    "profile": "https://forums.unraid.net/profile/79298-dyon/",
+    "title": "Dyon's Repository",
+    "index": 414
+  },
+  {
+    "url": "https://github.com/ItsEcholot/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/134301-echolot/",
+    "title": "Echolot's Repository",
+    "index": 415
+  },
+  {
+    "url": "https://github.com/EddCase/unRAID_Templates",
+    "profile": "https://forums.unraid.net/profile/10833-eddcase/",
+    "title": "EddCase's Repository",
+    "index": 416
+  },
+  {
+    "url": "https://github.com/egnerdata/unraid-docker-template-papra",
+    "profile": "https://forums.unraid.net/profile/274607-egnerdata/",
+    "title": "Egnerdata's Repository",
+    "index": 417
+  },
+  {
+    "url": "https://github.com/EideardVMR/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/204759-eideard/",
+    "title": "Eideard's Repository",
+    "index": 418
+  },
+  {
+    "url": "https://github.com/Eksistenze/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/153955-eksistenze/",
+    "title": "Eksistenze's Repository",
+    "index": 419
+  },
+  {
+    "url": "https://github.com/edgar971/open-chat",
+    "profile": "https://forums.unraid.net/profile/238357-el_pino/",
+    "title": "el_pino's Repository",
+    "index": 420
+  },
+  {
+    "url": "https://github.com/ElectricBrainUK/docker-templates",
+    "profile": "https://forums.unraid.net/profile/98185-electricbrainuk",
+    "title": "ElectricBrainUK's Repository",
+    "index": 421
+  },
+  {
+    "url": "https://github.com/anibridge/anibridge-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294357-eliasbenb/",
+    "title": "eliasbenb's Repository",
+    "index": 422
+  },
+  {
+    "url": "https://github.com/elzik/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/201488-elzik/",
+    "title": "elzik's Repository",
+    "index": 423
+  },
+  {
+    "url": "https://github.com/MediaBrowser/Emby.Build",
+    "profile": null,
+    "title": "Emby Repository",
+    "index": 424
+  },
+  {
+    "url": "https://github.com/rschuiling/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/261141-emphyrio/",
+    "title": "Emphyrio's Repository",
+    "index": 425
+  },
+  {
+    "url": "https://github.com/emptyfish/unraid-apps",
+    "profile": "https://forums.unraid.net/profile/112283-emptyfish/",
+    "title": "emptyfish's Repository",
+    "index": 426
+  },
+  {
+    "url": "https://github.com/Entree3k/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/201585-entree3000/",
+    "title": "entree3000's Repository",
+    "index": 427
+  },
+  {
+    "url": "https://github.com/twist3dimages/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/137900-exes/",
+    "title": "Exes' Repository",
+    "index": 428
+  },
+  {
+    "url": "https://github.com/peterthepeter/groly",
+    "profile": null,
+    "title": "facro's Repository",
+    "index": 429
+  },
+  {
+    "url": "https://github.com/stefan-matic/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/269247-fallen94/",
+    "title": "Fallen94's Repository",
+    "index": 430
+  },
+  {
+    "url": "https://github.com/andrejwithj/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/168139-fancyshmancy/",
+    "title": "fancyshmancy's Repository",
+    "index": 431
+  },
+  {
+    "url": "https://github.com/fanningert/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/77170-fanningert/",
+    "title": "fanningert's Repository",
+    "index": 432
+  },
+  {
+    "url": "https://github.com/fccview/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/293085-fccview/",
+    "title": "fccview's Repository",
+    "index": 433
+  },
+  {
+    "url": "https://github.com/fejich/unRAID-plugins-templates",
+    "profile": "https://forums.unraid.net/profile/122412-fejich/",
+    "title": "fejich's Repository",
+    "index": 434
+  },
+  {
+    "url": "https://github.com/fiR3W4LL87/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/113873-fir3w4ll/",
+    "title": "fiR3W4LL's Repository",
+    "index": 435
+  },
+  {
+    "url": "https://github.com/fisherd80/Listarr",
+    "profile": null,
+    "title": "fisherd91's Repository",
+    "index": 436
+  },
+  {
+    "url": "https://github.com/fizzyfrys/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119591-fizzyfrys/",
+    "title": "fizzyfrys' Repository",
+    "index": 437
+  },
+  {
+    "url": "https://github.com/Flight777/unraid_justworks_templates",
+    "profile": "https://forums.unraid.net/profile/119250-flight777",
+    "title": "Flight777's Repository",
+    "index": 438
+  },
+  {
+    "url": "https://github.com/CyanLabs/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/72406-fma965/",
+    "title": "Fma965's Repository",
+    "index": 439
+  },
+  {
+    "url": "https://github.com/johnngone/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/258273-forder/",
+    "title": "Forder's Repository",
+    "index": 440
+  },
+  {
+    "url": "https://github.com/EdwardChamberlain/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/122583-forum-layman/",
+    "title": "Forum-Layman's Repository",
+    "index": 441
+  },
+  {
+    "url": "https://github.com/fosrl/templates",
+    "profile": "https://forums.unraid.net/profile/96141-milo-schwartz/",
+    "title": "Fossorial's Repository",
+    "index": 442
+  },
+  {
+    "url": "https://github.com/FoxxMD/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/85599-foxxmd/",
+    "title": "FoxxMD's Repository",
+    "index": 443
+  },
+  {
+    "url": "https://github.com/frakman1/docker-templates",
+    "profile": "https://forums.unraid.net/profile/96005-frakman1",
+    "title": "frakman1's Repository",
+    "index": 444
+  },
+  {
+    "url": "https://github.com/FreakErn/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/129382-freakern/",
+    "title": "FreakErn's Repository",
+    "index": 445
+  },
+  {
+    "url": "https://gitlab.com/crafty-controller/crafty-4",
+    "profile": "https://forums.unraid.net/profile/126877-freddy0/",
+    "title": "freddy0's Repository",
+    "index": 446
+  },
+  {
+    "url": "https://github.com/friendlyFriend4000/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/244776-friendlyfriend/",
+    "title": "FriendlyFriend's Repository",
+    "index": 447
+  },
+  {
+    "url": "https://github.com/FunkeCoder23/unraid-templates/",
+    "profile": "https://forums.unraid.net/profile/273394-funkecoder23/",
+    "title": "FunkeCoder23's Repository",
+    "index": 448
+  },
+  {
+    "url": "https://github.com/fuzzy01/unraid_plg_repo",
+    "profile": "https://forums.unraid.net/profile/143886-fuzzy0101/",
+    "title": "Fuzzy0101's Repository",
+    "index": 449
+  },
+  {
+    "url": "https://github.com/ganey/unraid-honeygain",
+    "profile": "https://forums.unraid.net/profile/94003-ganey/",
+    "title": "ganey's Repository",
+    "index": 450
+  },
+  {
+    "url": "https://github.com/Garethp/rolemaster-era-server-unraid",
+    "profile": "https://forums.unraid.net/profile/243895-garethp/",
+    "title": "Garethp's Repository",
+    "index": 451
+  },
+  {
+    "url": "https://github.com/GEngines/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/290261-bmetpally/",
+    "title": "GEngines' Repository",
+    "index": 452
+  },
+  {
+    "url": "https://github.com/geoffgbsn/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/144116-geoffgibby/",
+    "title": "geoff.gibby's Repository",
+    "index": 453
+  },
+  {
+    "url": "https://github.com/ghzgod/signal-notification-unraid",
+    "profile": "https://forums.unraid.net/profile/293977-ghzgod11/",
+    "title": "ghzgod11's Repository",
+    "index": 454
+  },
+  {
+    "url": "https://github.com/gibz104/SpoolmanSync",
+    "profile": "https://forums.unraid.net/profile/293978-gibz104/",
+    "title": "gibz104's Repository",
+    "index": 455
+  },
+  {
+    "url": "https://github.com/Gill-Bates/unraid-app-templates",
+    "profile": "https://forums.unraid.net/profile/288881-gillbates/",
+    "title": "GillBates' Repository",
+    "index": 456
+  },
+  {
+    "url": "https://github.com/mecharmor/gog-free-claimer",
+    "profile": null,
+    "title": "GOG Free Games Claimer",
+    "index": 457
+  },
+  {
+    "url": "https://github.com/GoldnGroup/unraid-templates",
+    "profile": null,
+    "title": "GoldnGroup's Repository",
+    "index": 458
+  },
+  {
+    "url": "https://github.com/Goodhall-Solutions-ltd/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294974-goodhall-solutions/",
+    "title": "Goodhall Solutions' Repository",
+    "index": 459
+  },
+  {
+    "url": "https://github.com/googleg/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/282598-googleg/",
+    "title": "googleg's Repository",
+    "index": 460
+  },
+  {
+    "url": "https://github.com/got3nks/amutorrent",
+    "profile": "https://forums.unraid.net/profile/294555-got3nks/",
+    "title": "got3nks' Repository",
+    "index": 461
+  },
+  {
+    "url": "https://github.com/GregYankovoy/docker-templates",
+    "profile": "https://forums.unraid.net/profile/88760-grack/",
+    "title": "Grack's Repository",
+    "index": 462
+  },
+  {
+    "url": "https://github.com/gameyfin/unraid",
+    "profile": "https://forums.unraid.net/profile/249165-grimsi/",
+    "title": "grimsi's Repository",
+    "index": 463
+  },
+  {
+    "url": "https://github.com/Groestlcoin/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/281950-groestlcoin/",
+    "title": "groestlcoin's Repository",
+    "index": 464
+  },
+  {
+    "url": "https://github.com/reloadfast/unraid_template_LibreLinkUp_Uploader",
+    "profile": "https://forums.unraid.net/profile/125005-guillermomg/",
+    "title": "GuillermoMG's Repository",
+    "index": 465
+  },
+  {
+    "url": "https://github.com/HabiRabbu/Musicseerr",
+    "profile": "https://forums.unraid.net/profile/295022-habirabbu/",
+    "title": "HabiRabbu's Repository",
+    "index": 466
+  },
+  {
+    "url": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
+    "profile": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
+    "title": "hedrinbc's Repository",
+    "index": 467
+  },
+  {
+    "url": "https://github.com/helliott20/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/170827-helliott20/",
+    "title": "helliott20's Repository",
+    "index": 468
+  },
+  {
+    "url": "https://github.com/hernandito/docker-templates",
+    "profile": "https://forums.unraid.net/profile/6274-hernandito/",
+    "title": "hernandito's Repository",
+    "index": 469
+  },
+  {
+    "url": "https://github.com/hoody424/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/127129-hoody424/",
+    "title": "hoody424's Repository",
+    "index": 470
+  },
+  {
+    "url": "https://github.com/masterjb/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/124596-human-126094/",
+    "title": "Human-126094's Repository",
+    "index": 471
+  },
+  {
+    "url": "https://github.com/HuxyUK/docker-containers",
+    "profile": "https://forums.unraid.net/profile/70544-huxy/",
+    "title": "Huxy's Repository",
+    "index": 472
+  },
+  {
+    "url": "https://github.com/TheBinaryNinja/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/103361-iflip721/",
+    "title": "i.Flip721's Repository",
+    "index": 473
+  },
+  {
+    "url": "https://github.com/ikoyhn/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/128240-ikoyhn/",
+    "title": "ikoyhn's Repository",
+    "index": 474
+  },
+  {
+    "url": "https://github.com/imagegenius/templates",
+    "profile": "https://forums.unraid.net/profile/103573-vcxpz/",
+    "title": "imagegenius' Repository",
+    "index": 475
+  },
+  {
+    "url": "https://github.com/Inch-high/plexgeo",
+    "profile": "https://forums.unraid.net/profile/136949-inch/",
+    "title": "Inch's Repository",
+    "index": 476
+  },
+  {
+    "url": "https://github.com/Indemnity83/always-bring-a-gift",
+    "profile": "https://forums.unraid.net/profile/83781-indemnity83/",
+    "title": "Indemnity83's Repository",
+    "index": 477
+  },
+  {
+    "url": "https://github.com/Infotrend-Inc/CTPO",
+    "profile": "https://forums.unraid.net/profile/256461-infotrend-inc/",
+    "title": "Infotrend Inc's Repository",
+    "index": 478
+  },
+  {
+    "url": "https://github.com/ipdock/unraid-templates",
+    "profile": null,
+    "title": "ipdock's Repository",
+    "index": 479
+  },
+  {
+    "url": "https://github.com/Infotrend-Inc/OpenAI_WebUI",
+    "profile": "https://forums.unraid.net/profile/256461-iti/",
+    "title": "ITI's Repository",
+    "index": 480
+  },
+  {
+    "url": "https://github.com/itimpi/Unraid-CA-Templates",
+    "profile": "https://forums.unraid.net/profile/10897-itimpi/",
+    "title": "itimpi's Repository",
+    "index": 481
+  },
+  {
+    "url": "https://github.com/itsnotashley/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/287054-itsnotashley/",
+    "title": "itsnotashley's Repository",
+    "index": 482
+  },
+  {
+    "url": "https://github.com/ngfchl/ptools_unraid_template",
+    "profile": "https://forums.unraid.net/profile/268036-jacksonnie/",
+    "title": "JacksonNie's Repository",
+    "index": 483
+  },
+  {
+    "url": "https://github.com/what-name/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/122982-jacob-bolooni/",
+    "title": "Jacob Bolooni's Repository",
+    "index": 484
+  },
+  {
+    "url": "https://github.com/JACOBSMILE/Unraid_XMLS",
+    "profile": "https://forums.unraid.net/profile/141756-jacobsmile/",
+    "title": "JACOBSMILE's Repository",
+    "index": 485
+  },
+  {
+    "url": "https://github.com/jadehawk/unRaid-Templates",
+    "profile": "https://forums.unraid.net/profile/168612-jadehawk",
+    "title": "Jadehawk's Repository",
+    "index": 486
+  },
+  {
+    "url": "https://github.com/jcoker85/UnraidTemplates",
+    "profile": "https://forums.unraid.net/profile/255902-jamxx/",
+    "title": "Jamxx's Repository",
+    "index": 487
+  },
+  {
+    "url": "https://github.com/jandrop/file_core_api_unraid",
+    "profile": "https://forums.unraid.net/profile/111434-jandrop/",
+    "title": "jandrop's Repository",
+    "index": 488
+  },
+  {
+    "url": "https://github.com/JW-CH/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/268715-janmer/",
+    "title": "janmer's Repository",
+    "index": 489
+  },
+  {
+    "url": "https://github.com/jarvis2f/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/284045-jarvis2f/",
+    "title": "jarvis2f's Repository",
+    "index": 490
+  },
+  {
+    "url": "https://github.com/jassycliq/Unraid-AndroidStudio-Projector",
+    "profile": "https://forums.unraid.net/profile/116233-jassycliq/",
+    "title": "jassycliq's Repository",
+    "index": 491
+  },
+  {
+    "url": "https://github.com/jaydenroberts/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/175884-jaydenroberts/",
+    "title": "JaydenRoberts' Repository",
+    "index": 492
+  },
+  {
+    "url": "https://github.com/jbartlett777/DiskSpeed",
+    "profile": "https://forums.unraid.net/profile/8307-jbartlett/",
+    "title": "JBartlett's Repository",
+    "index": 493
+  },
+  {
+    "url": "https://github.com/jbreed/docker-templates",
+    "profile": "https://forums.unraid.net/profile/92695-jbreed/",
+    "title": "jbreed's Repository",
+    "index": 494
+  },
+  {
+    "url": "https://github.com/Jcloud67/Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/67922-jcloud/",
+    "title": "JCloud's Repository",
+    "index": 495
+  },
+  {
+    "url": "https://github.com/jcreynolds/docker-templates",
+    "profile": "https://forums.unraid.net/profile/65204-jcreynoldsii/",
+    "title": "jcreynolds' Repository",
+    "index": 496
+  },
+  {
+    "url": "https://github.com/jjermany/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/288757-jermcee/",
+    "title": "jermcee's Repository",
+    "index": 497
+  },
+  {
+    "url": "https://github.com/jessielw/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/201686-jessielw/",
+    "title": "Jessielw's Repository",
+    "index": 498
+  },
+  {
+    "url": "https://github.com/jflo/ffsync-unraid",
+    "profile": "https://forums.unraid.net/profile/120634-jflo/",
+    "title": "Jflo's Repository",
+    "index": 499
+  },
+  {
+    "url": "https://github.com/GladysAssistant/unraid-gladys-templates",
+    "profile": "https://forums.unraid.net/profile/159169-jgcb00/",
+    "title": "jgcb00's Repository",
+    "index": 500
+  },
+  {
+    "url": "https://github.com/jinlife/docker-templates",
+    "profile": "https://forums.unraid.net/profile/119719-jinlife/",
+    "title": "jinlife's Repository",
+    "index": 501
+  },
+  {
+    "url": "https://github.com/jkirkcaldy/unraid-CA-templates",
+    "profile": "https://forums.unraid.net/profile/114408-jkirkcaldy/",
+    "title": "jkirkcaldy's Repository",
+    "index": 502
+  },
+  {
+    "url": "https://github.com/joch/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/2607-joch/",
+    "title": "joch's Repository",
+    "index": 503
+  },
+  {
+    "url": "https://github.com/johnpwhite/unraid-community-applications-index",
+    "profile": "https://forums.unraid.net/profile/5686-johner/",
+    "title": "johner's Repository",
+    "index": 504
+  },
+  {
+    "url": "https://github.com/b1tsized/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/112763-johnwesturner/",
+    "title": "johnwesturner's Repository",
+    "index": 505
+  },
+  {
+    "url": "https://github.com/Joly0/docker-templates",
+    "profile": "https://forums.unraid.net/profile/86760-joly0/",
+    "title": "joly0's Repository",
+    "index": 506
+  },
+  {
+    "url": "https://github.com/jorgenman/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/142946-jorgenman/",
+    "title": "jorgenman's Repository",
+    "index": 507
+  },
+  {
+    "url": "https://github.com/qubex22/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/110563-joroga22/",
+    "title": "joroga22's Repository",
+    "index": 508
+  },
+  {
+    "url": "https://github.com/josh-gaby/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/171871-joshgaby/",
+    "title": "josh.gaby's Repository",
+    "index": 509
+  },
+  {
+    "url": "https://github.com/Joshndroid/joshndroid-unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/123042-joshndroid/",
+    "title": "Joshndroid's Repository",
+    "index": 510
+  },
+  {
+    "url": "https://github.com/angelics/unraid-docker-template",
+    "profile": "https://forums.unraid.net/profile/7122-josywong/",
+    "title": "josywong's Repository",
+    "index": 511
+  },
+  {
+    "url": "https://github.com/josecoelho/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/125944-jos%C3%A9-coelho/",
+    "title": "Jos\u00e9 Coelho's Repository",
+    "index": 512
+  },
+  {
+    "url": "https://github.com/JourneyDocker/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/284186-journeyover/",
+    "title": "JourneyOver's Repository",
+    "index": 513
+  },
+  {
+    "url": "https://github.com/JPDVM2014/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/156525-jpdvm2014/",
+    "title": "JPDVM2014's Repository",
+    "index": 514
+  },
+  {
+    "url": "https://github.com/jsatk/unraid-templates",
+    "profile": null,
+    "title": "jsatk's unraid templates",
+    "index": 515
+  },
+  {
+    "url": "https://github.com/jsavargas/telethon_downloader",
+    "profile": "https://forums.unraid.net/profile/93593-jsavargas/",
+    "title": "jsavargas' Repository",
+    "index": 516
+  },
+  {
+    "url": "https://github.com/jterpstra1/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/92505-jterpstra/",
+    "title": "jterpstra's Repository",
+    "index": 517
+  },
+  {
+    "url": "https://github.com/JudoChinX/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/287737-judochinx/",
+    "title": "JudoChinX's Repository",
+    "index": 518
+  },
+  {
+    "url": "https://github.com/shaf/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/71085-jugniji/",
+    "title": "JugniJi's Repository",
+    "index": 519
+  },
+  {
+    "url": "https://github.com/JustinAiken/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/1079-justinaiken/",
+    "title": "JustinAiken's Repository",
+    "index": 520
+  },
+  {
+    "url": "https://github.com/Olprog59/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/121454-kameleon83/",
+    "title": "Kameleon83's Repository",
+    "index": 521
+  },
+  {
+    "url": "https://github.com/KasteM34/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169707-kastem34/",
+    "title": "kastem34's Repository",
+    "index": 522
+  },
+  {
+    "url": "https://github.com/keenaanee/CinemaStatus",
+    "profile": "https://forums.unraid.net/profile/271535-keenaanee/",
+    "title": "Keenaanee's Repository",
+    "index": 523
+  },
+  {
+    "url": "https://github.com/roninkenji/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/62359-ken-ji/",
+    "title": "ken-ji's Repository",
+    "index": 524
+  },
+  {
+    "url": "https://github.com/kezzkezzkezz/UNRAID-Templates/",
+    "profile": "https://forums.unraid.net/profile/133849-kezzkezzkezz/",
+    "title": "kezzkezzkezz's Repository",
+    "index": 525
+  },
+  {
+    "url": "https://github.com/kilrah/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/175398-kilrah/",
+    "title": "Kilrah's Repository",
+    "index": 526
+  },
+  {
+    "url": "https://github.com/kiowadriver/unraid-docker",
+    "profile": "https://forums.unraid.net/profile/74645-kiowa2005/",
+    "title": "kiowa2005's Repository",
+    "index": 527
+  },
+  {
+    "url": "https://github.com/Knoxie/UnraidTemplates",
+    "profile": "https://forums.unraid.net/profile/78069-knoxie89/",
+    "title": "Knoxie89's Repository",
+    "index": 528
+  },
+  {
+    "url": "https://github.com/S0CT/fsm",
+    "profile": "https://forums.unraid.net/profile/275440-kognac/",
+    "title": "Kognac's Repository",
+    "index": 529
+  },
+  {
+    "url": "https://github.com/Kostecki/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/68040-kostecki/",
+    "title": "kostecki's Repository",
+    "index": 530
+  },
+  {
+    "url": "https://github.com/Kru-x/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/69435-kru-x/",
+    "title": "Kru-X's Repository",
+    "index": 531
+  },
+  {
+    "url": "https://github.com/Qlisch/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119212-kulisch/",
+    "title": "Kulisch's Repository",
+    "index": 532
+  },
+  {
+    "url": "https://github.com/Kurotaku-sama/Unraid-Plugins-Repository",
+    "profile": "https://forums.unraid.net/profile/277881-kurotaku/",
+    "title": "Kurotaku's Repository",
+    "index": 533
+  },
+  {
+    "url": "https://github.com/kywarai/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/170658-kuuki/",
+    "title": "kuuki's Repository",
+    "index": 534
+  },
+  {
+    "url": "https://github.com/Srcodesalittle/cryptgeon_redis",
+    "profile": "https://forums.unraid.net/profile/131563-lamp/",
+    "title": "lamp's Repository",
+    "index": 535
+  },
+  {
+    "url": "https://github.com/Revise0592/unraid-apps",
+    "profile": null,
+    "title": "Larv's Repository",
+    "index": 536
+  },
+  {
+    "url": "https://github.com/laur89/unraid-templates/",
+    "profile": "https://forums.unraid.net/profile/114193-laur/",
+    "title": "laur's Repository",
+    "index": 537
+  },
+  {
+    "url": "https://github.com/laurensguijt/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/254983-laurensguijt/",
+    "title": "Laurensguijt's Repository",
+    "index": 538
+  },
+  {
+    "url": "https://github.com/lawryder/unraid_docker_reps",
+    "profile": "https://forums.unraid.net/profile/122425-lawryder/",
+    "title": "LawRyder's Repository",
+    "index": 539
+  },
+  {
+    "url": "https://github.com/murtaza-nasir/speakr-unraid",
+    "profile": "https://github.com/murtaza-nasir/speakr-unraid",
+    "title": "learnedmachine's Repository",
+    "index": 540
+  },
+  {
+    "url": "https://github.com/lewislarsen/lldap-unraid",
+    "profile": "https://forums.unraid.net/profile/143760-lewis-l/",
+    "title": "Lewis L's Repository",
+    "index": 541
+  },
+  {
+    "url": "https://github.com/L1cardo/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/128967-licardo/",
+    "title": "licardo's Repository",
+    "index": 542
+  },
+  {
+    "url": "https://github.com/linuxserver/linuxserver-Plugin-Repository",
+    "profile": null,
+    "title": "Linuxserver's Plugin Repository",
+    "index": 543
+  },
+  {
+    "url": "https://github.com/liorbass/tandarr-unraid-templates",
+    "profile": null,
+    "title": "LioirBass' Repository",
+    "index": 544
+  },
+  {
+    "url": "https://github.com/locus313/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/74415-locus313/",
+    "title": "locus313's Repository",
+    "index": 545
+  },
+  {
+    "url": "https://github.com/Maitresinh/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/280760-logan23/",
+    "title": "logan23's Repository",
+    "index": 546
+  },
+  {
+    "url": "https://github.com/mingzaily/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/169573-longyunur/",
+    "title": "LongYunar's Repository",
+    "index": 547
+  },
+  {
+    "url": "https://github.com/Loony2392/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/152355-loony2392/",
+    "bio": "",
+    "icon": "https://raw.githubusercontent.com/Loony2392/unraid-templates/main/icons/avatar.gif",
+    "DonateLink": "https://ko-fi.com/loony_tech",
+    "DonateText": "If you like my work please consider Donating.",
+    "Forum": "https://forums.unraid.net/profile/152355-loony2392/",
+    "title": "Loony2392's Repository",
+    "index": 548
+  },
+  {
+    "url": "https://github.com/timespacedecay/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/121604-lostinspace/",
+    "title": "lostinspace's Repository",
+    "index": 549
+  },
+  {
+    "url": "https://github.com/lucamarchiori/OwnTracksRecorderUnraid",
+    "profile": "https://forums.unraid.net/profile/255135-lucamarchiori/",
+    "title": "lucamarchiori's Repository",
+    "index": 550
+  },
+  {
+    "url": "https://github.com/luisalrp/unraid_docker_templates",
+    "profile": "https://forums.unraid.net/profile/115058-luisalrp/",
+    "title": "luisalrp's Repository",
+    "index": 551
+  },
+  {
+    "url": "https://github.com/lumbeecheraw75/unraid-templates",
+    "profile": null,
+    "title": "lumbeecheraw75's Repository",
+    "index": 552
+  },
+  {
+    "url": "https://github.com/l4rm4nd/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/279319-lrvt/",
+    "title": "LVRT's Repository",
+    "index": 553
+  },
+  {
+    "url": "https://github.com/macexx/docker-templates",
+    "profile": "https://forums.unraid.net/profile/66302-macester/",
+    "title": "macester's Repository",
+    "index": 554
+  },
+  {
+    "url": "https://github.com/MROGHUB/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/282192-mackattack/",
+    "title": "MackAttack's Repository",
+    "index": 555
+  },
+  {
+    "url": "https://github.com/mackid1993/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/74622-mackid1993/",
+    "title": "Mackid1993's Repository",
+    "index": 556
+  },
+  {
+    "url": "https://github.com/jo-sobo/scriptlogs-unraid-plugin",
+    "profile": "https://forums.unraid.net/profile/120452-magnum308/",
+    "title": "Magnum.308's Repository",
+    "index": 557
+  },
+  {
+    "url": "https://github.com/Maikboarder/Playerr",
+    "profile": "https://forums.unraid.net/profile/293293-maikboarder/",
+    "title": "Maikboarder's Repository",
+    "index": 558
+  },
+  {
+    "url": "https://github.com/Malfurious/docker-templates",
+    "profile": "https://forums.unraid.net/profile/77149-malfurious/",
+    "title": "malfurious' Repository",
+    "index": 559
+  },
+  {
+    "url": "https://github.com/malkiebr/unraid-localtonet",
+    "profile": "https://forums.unraid.net/profile/234461-malkie/",
+    "title": "malkie's Repository",
+    "index": 560
+  },
+  {
+    "url": "https://github.com/malvarez00/unRAID-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/77549-malvarez00/",
+    "title": "malvarez00's Repository",
+    "index": 561
+  },
+  {
+    "url": "https://github.com/mandarons/icloud-drive-docker",
+    "profile": "https://forums.unraid.net/profile/278021-mandarons/",
+    "title": "mandarons' Repository",
+    "index": 562
+  },
+  {
+    "url": "https://github.com/PonyLucky/TendaControllerXML",
+    "profile": "https://forums.unraid.net/profile/177818-margot/",
+    "title": "Margot's Repository",
+    "index": 563
+  },
+  {
+    "url": "https://github.com/MarkusMcNugen/docker-templates",
+    "profile": "https://forums.unraid.net/profile/79684-markusmcnugen/",
+    "title": "MarkusMcNugen's Repository",
+    "index": 564
+  },
+  {
+    "url": "https://github.com/Marraz/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/127460-marraz/",
+    "title": "Marraz' Repository",
+    "index": 565
+  },
+  {
+    "url": "https://github.com/mash2k3/unraid-templates",
+    "profile": null,
+    "title": "mash2k3's Repository",
+    "index": 566
+  },
+  {
+    "url": "https://github.com/rantanlan/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/914-mason",
+    "title": "mason's Repository",
+    "index": 567
+  },
+  {
+    "url": "https://github.com/mastiffmushroom/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/243288-mastiffmushroom/",
+    "title": "MastiffMushroom's Repository",
+    "index": 568
+  },
+  {
+    "url": "https://github.com/matda59/video-to-mp3-converter",
+    "profile": "https://forums.unraid.net/profile/119423-matda59/",
+    "title": "matda59's Repository",
+    "index": 569
+  },
+  {
+    "url": "https://github.com/mattheworres/docker-templates",
+    "profile": "https://forums.unraid.net/profile/115370-matthew-orres/",
+    "title": "Matthew Orres' Repository",
+    "index": 570
+  },
+  {
+    "url": "https://github.com/PepaonDrugs/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/157546-maxi_fpv/",
+    "title": "Maxi_Fpv's Repository",
+    "index": 571
+  },
+  {
+    "url": "https://github.com/maybegrim/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294736-maybegrim/",
+    "title": "MaybeGrim's Repository",
+    "index": 572
+  },
+  {
+    "url": "https://github.com/mayo-248/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/175387-mayo_248/",
+    "title": "Mayo_248's Repository",
+    "index": 573
+  },
+  {
+    "url": "https://github.com/mbirnbach/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/291521-mbirnbach/",
+    "title": "mbirnbach's Repository",
+    "index": 574
+  },
+  {
+    "url": "https://github.com/mccann6/unraid-templates/",
+    "profile": "https://forums.unraid.net/profile/293805-mccann6/",
+    "title": "mccann6's Repository",
+    "index": 575
+  },
+  {
+    "url": "https://github.com/mcdays94/docker-templates",
+    "profile": null,
+    "title": "mcdays94's Repository",
+    "index": 576
+  },
+  {
+    "url": "https://github.com/McJoppy/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/250622-mcraidy/",
+    "title": "mcraidy's Repository",
+    "index": 577
+  },
+  {
+    "url": "https://github.com/mdarkness1988/rust-server-template",
+    "profile": "https://forums.unraid.net/profile/84443-mdarkness1988/",
+    "title": "mdarkness1988's Repository",
+    "index": 578
+  },
+  {
+    "url": "https://github.com/OctoPrint/Unraid-Template",
+    "profile": "https://forums.unraid.net/profile/100446-mearman",
+    "title": "mearman's 2nd Repository",
+    "index": 579
+  },
+  {
+    "url": "https://github.com/NotExpectedYet/OctoFarm-UnRaid-Template",
+    "profile": "https://forums.unraid.net/profile/100446-mearman",
+    "title": "mearman's Repository",
+    "index": 580
+  },
+  {
+    "url": "https://github.com/mediux-team/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/125333-mmoosem/",
+    "title": "Mediux-Team's Repository",
+    "index": 581
+  },
+  {
+    "url": "https://github.com/kiwimato/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/89549-mihai/",
+    "title": "Mihai's Repository",
+    "index": 582
+  },
+  {
+    "url": "https://github.com/helfrichmichael/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/68815-mikeah/",
+    "title": "MikeAH's Repository",
+    "index": 583
+  },
+  {
+    "url": "https://github.com/mikedhanson/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/88846-mikehanson/",
+    "title": "mikehanson's Repository",
+    "index": 584
+  },
+  {
+    "url": "https://github.com/mikeylikesrocks/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/89382-mikeylikesrocks",
+    "title": "mikeylikesrocks' Repository",
+    "index": 585
+  },
+  {
+    "url": "https://github.com/misterjtc/docker-templates",
+    "profile": "https://forums.unraid.net/profile/68425-misterjtc/",
+    "title": "Misterjtc's Repository",
+    "index": 586
+  },
+  {
+    "url": "https://github.com/mizz141/mizz141-unraid-xml",
+    "profile": "https://forums.unraid.net/profile/98815-mizz141/",
+    "title": "Mizz141's Repository",
+    "index": 587
+  },
+  {
+    "url": "https://github.com/m-klecka/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/210341-mklecka/",
+    "title": "mklecka's Repository",
+    "index": 588
+  },
+  {
+    "url": "https://github.com/mlapaglia/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/100043-mlapaglia/",
+    "title": "mlapaglia's Repository",
+    "index": 589
+  },
+  {
+    "url": "https://github.com/mlebjerg/docker-templates",
+    "profile": "https://forums.unraid.net/profile/76816-mlebjerg/",
+    "title": "mlebjerg's Repository",
+    "index": 590
+  },
+  {
+    "url": "https://github.com/MMagTech/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/108975-mmagtech/",
+    "title": "MMagTech's Repository",
+    "index": 591
+  },
+  {
+    "url": "https://github.com/MobiusNine/docker-templates",
+    "profile": "https://forums.unraid.net/profile/84666-mobiusnine/",
+    "title": "MobiusNine's Repository",
+    "index": 592
+  },
+  {
+    "url": "https://github.com/crgodfrey/unraid-froggi",
+    "profile": "https://forums.unraid.net/profile/274467-monkeyss/",
+    "title": "monkeyss' Repository",
+    "index": 593
+  },
+  {
+    "url": "https://github.com/MorgothRB/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/280956-morgoth/",
+    "title": "Morgoth's Repository",
+    "index": 594
+  },
+  {
+    "url": "https://github.com/moritzfl/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/145080-moritzf/",
+    "title": "moritzf's Repository",
+    "index": 595
+  },
+  {
+    "url": "https://github.com/mplogas/unraid-containers",
+    "profile": "https://forums.unraid.net/profile/145679-mplogas/",
+    "title": "mplogas' Repository",
+    "index": 596
+  },
+  {
+    "url": "https://github.com/crazyqin/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/157513-mrafter/",
+    "title": "mrafter's Repository",
+    "index": 597
+  },
+  {
+    "url": "https://github.com/dalekseevs/Unraid-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/74482-mrchunky",
+    "title": "MrChunky's Repository",
+    "index": 598
+  },
+  {
+    "url": "https://github.com/MrCorehh/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/293911-mrcorehh/",
+    "title": "MrCorehh's Repository",
+    "index": 599
+  },
+  {
+    "url": "https://github.com/JulienPlomteux/Unraid-ErgoNode",
+    "profile": "https://forums.unraid.net/profile/163009-mrlafontaine/",
+    "title": "mrlafontaine's Repository",
+    "index": 600
+  },
+  {
+    "url": "https://github.com/mstrhakr/plugin-repository",
+    "profile": "https://forums.unraid.net/profile/119750-mstrhakr",
+    "title": "mstrhakr's Repository",
+    "index": 601
+  },
+  {
+    "url": "https://github.com/mtrogman/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/115379-mtrogman/",
+    "title": "mtrogman's Repository",
+    "index": 602
+  },
+  {
+    "url": "https://github.com/Mudislander/docker-templates",
+    "profile": "https://forums.unraid.net/profile/67039-mudislander/",
+    "title": "Mudislander's Repository",
+    "index": 603
+  },
+  {
+    "url": "https://github.com/Muwahhidun/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/107652-muwahhid/",
+    "title": "Muwahhidun's Repository",
+    "index": 604
+  },
+  {
+    "url": "https://github.com/Muxelmann/unraid-app_anaconda3",
+    "profile": "https://forums.unraid.net/profile/238596-muxelmann/",
+    "title": "muxelmann's Repository",
+    "index": 605
+  },
+  {
+    "url": "https://github.com/MyFaith/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/157465-myfaith/",
+    "title": "MyFaith's Repository",
+    "index": 606
+  },
+  {
+    "url": "https://github.com/Nackophilz/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/161066-nackophilz/",
+    "title": "Nackophilz's Repository",
+    "index": 607
+  },
+  {
+    "url": "https://github.com/metronade/unraid-templates",
+    "profile": null,
+    "title": "nade's Repository",
+    "index": 608
+  },
+  {
+    "url": "https://github.com/ne0ark/docker-templates",
+    "profile": "https://forums.unraid.net/profile/221895-naidu/",
+    "title": "Naidu's Repository",
+    "index": 609
+  },
+  {
+    "url": "https://github.com/natcoso9955/unRAID-docker",
+    "profile": "https://forums.unraid.net/profile/73128-natcoso9955/",
+    "title": "Natcoso9955's Repository",
+    "index": 610
+  },
+  {
+    "url": "https://github.com/NebN/unraid-apps",
+    "profile": "https://forums.unraid.net/profile/274578-nebn/",
+    "title": "NebN's Repository",
+    "index": 611
+  },
+  {
+    "url": "https://github.com/nebula-codes/hytale_server_manager",
+    "profile": "https://forums.unraid.net/profile/293434-nebulacodes/",
+    "title": "Nebula's Repository",
+    "index": 612
+  },
+  {
+    "url": "https://github.com/netpersona/popcorn-unraid",
+    "profile": "https://forums.unraid.net/profile/234637-smackmybones/",
+    "title": "Netpersona's Repository",
+    "index": 613
+  },
+  {
+    "url": "https://github.com/neur0map/deskmon-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/294130-neur0map/",
+    "title": "Neur0map's Repository",
+    "index": 614
+  },
+  {
+    "url": "https://github.com/JFLXCLOUD/NeXroll",
+    "profile": null,
+    "title": "NeXroll's Repository",
+    "index": 615
+  },
+  {
+    "url": "https://github.com/NickBorgers/unraid-apps",
+    "profile": "https://forums.unraid.net/profile/69750-nickborgers/",
+    "title": "Nick Borgers' Repository",
+    "index": 616
+  },
+  {
+    "url": "https://github.com/NickBootOne/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/93263-nickboot/",
+    "title": "nickboot's Repository",
+    "index": 617
+  },
+  {
+    "url": "https://github.com/NixonInnes/unraid-builds-xml",
+    "profile": "https://forums.unraid.net/profile/122748-nixoninnes/",
+    "title": "NixonInnes' Repository",
+    "index": 618
+  },
+  {
+    "url": "https://github.com/MitchellThompkins/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/285040-not_a_real_human/",
+    "title": "not_a_real_human's Repository",
+    "index": 619
+  },
+  {
+    "url": "https://github.com/NSPManager/NSPanelManager",
+    "profile": null,
+    "title": "NSPManager's Repository",
+    "index": 620
+  },
+  {
+    "url": "https://github.com/nullata/unraid-images",
+    "profile": "https://forums.unraid.net/profile/229913-nullata/",
+    "title": "nullata's Repository",
+    "index": 621
+  },
+  {
+    "url": "https://github.com/nylonee/watchlistarr-unraid",
+    "profile": "https://forums.unraid.net/profile/142159-nylonee/",
+    "title": "nylonee's Repository",
+    "index": 622
+  },
+  {
+    "url": "https://github.com/nyxtron/unraid-templates",
+    "profile": null,
+    "title": "Nyxtron's Repository",
+    "index": 623
+  },
+  {
+    "url": "https://github.com/ObviousViking/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/114882-obviousviking/",
+    "title": "ObviousViking's Repository",
+    "index": 624
+  },
+  {
+    "url": "https://github.com/OFark/docker-templates",
+    "profile": "https://forums.unraid.net/profile/86513-ofark/",
+    "title": "OFark's Repository",
+    "index": 625
+  },
+  {
+    "url": "https://github.com/ofawx/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/109310-ofawx/",
+    "title": "ofawx's Repository",
+    "index": 626
+  },
+  {
+    "url": "https://github.com/plexinc/pms-docker",
+    "profile": null,
+    "shortName": "Plex",
+    "title": "Official Plex Repository",
+    "index": 627
+  },
+  {
+    "url": "https://github.com/ijabz/songkong_unraid/",
+    "profile": null,
+    "shortName": "Songkong",
+    "title": "Official Songkong Repository",
+    "index": 628
+  },
+  {
+    "url": "https://github.com/unraid/docker-templates",
+    "profile": null,
+    "shortName": "Unraid",
+    "title": "Official Unraid Plugin Repository",
+    "index": 629
+  },
+  {
+    "url": "https://github.com/wizarrrr/wizarr",
+    "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
+    "title": "Official Wizarr Repository",
+    "index": 630
+  },
+  {
+    "url": "https://github.com/oldcrazyeye/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/124305-oldcrazyeye/",
+    "title": "oldcrazyeye's Repository",
+    "index": 631
+  },
+  {
+    "url": "https://github.com/0neTX/UnRAID_Template",
+    "profile": "https://forums.unraid.net/profile/161660-onetx/",
+    "title": "onetx's Repository",
+    "index": 632
+  },
+  {
+    "url": "https://github.com/opal06/unraid_docker_templates",
+    "profile": "https://forums.unraid.net/profile/110756-opal_06/",
+    "title": "opal_06's Repository",
+    "index": 633
+  },
+  {
+    "url": "https://github.com/openspeedtest/unraid-docker-plugin",
+    "profile": "https://forums.unraid.net/profile/110999-openspeedtest/",
+    "title": "openspeedtest's Repository",
+    "index": 634
+  },
+  {
+    "url": "https://github.com/orangecoding/fredy-unraid-template",
+    "profile": "https://forums.unraid.net/profile/292517-orangecoding/",
+    "title": "Orangecoding's Repository",
+    "index": 635
+  },
+  {
+    "url": "https://github.com/pacnpal/unraid-templates/",
+    "profile": "https://forums.unraid.net/profile/263235-pacnpal/",
+    "title": "pacnpal's Repository",
+    "index": 636
+  },
+  {
+    "url": "https://github.com/theodorecharles/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/103598-paloooz/",
+    "title": "paloooz's Repository",
+    "index": 637
+  },
+  {
+    "url": "https://github.com/ruaan-deysel/unraid-apps",
+    "profile": "https://forums.unraid.net/profile/98076-panicmechanic007/",
+    "title": "PanicMechanic007's Repository",
+    "index": 638
+  },
+  {
+    "url": "https://github.com/PartitionPixel/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119008-partition-pixel/",
+    "title": "Partition Pixel's Repository",
+    "index": 639
+  },
+  {
+    "url": "https://github.com/patrickstigler/unraid_app_templates",
+    "profile": "https://forums.unraid.net/profile/139758-maddash1337/",
+    "title": "patrickstigler's Repository",
+    "index": 640
+  },
+  {
+    "url": "https://github.com/pawelmalak/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/119205-paululibro/",
+    "title": "paululibro's Repository",
+    "index": 641
+  },
+  {
+    "url": "https://github.com/pducharme/docker-containers",
+    "profile": "https://forums.unraid.net/profile/62479-pducharme/",
+    "title": "pducharme's Repository",
+    "index": 642
+  },
+  {
+    "url": "https://github.com/Petelombardo/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/293917-pete-l/",
+    "title": "Pete L's Repository",
+    "index": 643
+  },
+  {
+    "url": "https://github.com/mpcdigitize/docker-templates",
+    "profile": "https://forums.unraid.net/profile/249625-petel/",
+    "title": "PeteL's Repository",
+    "index": 644
+  },
+  {
+    "url": "https://github.com/phyzical/UnraidPlugins",
+    "profile": "https://forums.unraid.net/profile/97031-phyzical/",
+    "title": "phyzical's Repository",
+    "index": 645
+  },
+  {
+    "url": "https://github.com/Piratkopia13/unraid-buddybackup",
+    "profile": "https://forums.unraid.net/profile/158066-pirat/",
+    "title": "Pirat's Repository",
+    "index": 646
+  },
+  {
+    "url": "https://github.com/Uloga1/pre-seederr",
+    "profile": "https://forums.unraid.net/profile/264035-pirlet/",
+    "title": "pirlet's Repository",
+    "index": 647
+  },
+  {
+    "url": "https://github.com/silkyclouds/PMDA_unraid_xml",
+    "profile": "https://forums.unraid.net/profile/170800-meaning/",
+    "title": "PMDA's Repository",
+    "index": 648
+  },
+  {
+    "url": "https://github.com/poke0/Unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/139781-poke0/",
+    "title": "Poke0's Repository",
+    "index": 649
+  },
+  {
+    "url": "https://github.com/benjaminRoberts01375/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/290281-preposterous/",
+    "title": "Preposterous' Repository",
+    "index": 650
+  },
+  {
+    "url": "https://github.com/dcflachs/plugin-repository",
+    "profile": "https://forums.unraid.net/profile/63584-primeval_god/",
+    "title": "primeval_god's Repository",
+    "index": 651
+  },
+  {
+    "url": "https://github.com/killforby/chibisafe",
+    "profile": "https://forums.unraid.net/profile/229087-professeurx/",
+    "title": "professeurx's Repository",
+    "index": 652
+  },
+  {
+    "url": "https://github.com/Progeny42/unRAID-CA-Templates",
+    "profile": "https://forums.unraid.net/profile/101997-progeny42",
+    "title": "Progeny42's Repository",
+    "index": 653
+  },
+  {
+    "url": "https://github.com/justjoseorg/Unraid-Intel_Ollama",
+    "profile": "https://forums.unraid.net/profile/261082-possessive-small6053/",
+    "title": "progressive-small6053's Repository",
+    "index": 654
+  },
+  {
+    "url": "https://github.com/ProphetSe7en/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/89667-prophetse7en/",
+    "title": "ProphetSe7en's Repository",
+    "index": 655
+  },
+  {
+    "url": "https://github.com/Pross/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/164140-pross/",
+    "title": "pross' Repository",
+    "index": 656
+  },
+  {
+    "url": "https://github.com/ptchernegovski/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/99869-ptchernegovski/",
+    "title": "ptchernegovski's Repository",
+    "index": 657
+  },
+  {
+    "url": "https://github.com/OctoEverywhere/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/289064-quinninator/",
+    "title": "Quinninator's Repository",
+    "index": 658
+  },
+  {
+    "url": "https://github.com/kikootwo/ReadMeABook",
+    "profile": "https://forums.unraid.net/profile/293929-kikootwo/",
+    "title": "ReadMeABook's Repository",
+    "index": 659
+  },
+  {
+    "url": "https://github.com/picthor-io/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/106558-realcnbs/",
+    "title": "realcnbs' Repository",
+    "index": 660
+  },
+  {
+    "url": "https://github.com/DavidWJR/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/253276-reggieswag/",
+    "title": "ReggieSwag's Repository",
+    "index": 661
+  },
+  {
+    "url": "https://github.com/Michuelnik/docker-mediathekview-web",
+    "profile": "https://forums.unraid.net/profile/153213-revan335/",
+    "title": "Reven335's Repository",
+    "index": 662
+  },
+  {
+    "url": "https://github.com/R3yn4ld/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/77730-reynald/",
+    "title": "Reynald's Repository",
+    "index": 663
+  },
+  {
+    "url": "https://github.com/rezo552/unraid-ltfs/",
+    "profile": "https://forums.unraid.net/profile/271555-rezo552/",
+    "title": "ReZo552's Repository",
+    "index": 664
+  },
+  {
+    "url": "https://github.com/wger-project/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/118956-rge/",
+    "title": "rge's Repository",
+    "index": 665
+  },
+  {
+    "url": "https://github.com/Richy1989/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/125824-richy1989/",
+    "title": "Richy1989's Repository",
+    "index": 666
+  },
+  {
+    "url": "http://github.com/RiDDiX/uraid-templates",
+    "profile": "https://forums.unraid.net/profile/123957-riddix/",
+    "title": "RiDDiX's Repository",
+    "index": 667
+  },
+  {
+    "url": "https://github.com/riffsphereha/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/250924-riffsphereha/",
+    "title": "RiffSphereHA's Repository",
+    "index": 668
+  },
+  {
+    "url": "https://github.com/ibigsnet/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/76488-riflejock/",
+    "title": "RifleJock's Repository",
+    "index": 669
+  },
+  {
+    "url": "https://github.com/ripleyXLR8/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/101434-ripleyxlr8/",
+    "title": "ripleyxlr8's Repository",
+    "index": 670
+  },
+  {
+    "url": "https://github.com/Ratomas/CA_XML",
+    "profile": "https://forums.unraid.net/profile/85867-robert-thomas/",
+    "title": "Robert Thomas' Repository",
+    "index": 671
+  },
+  {
+    "url": "https://github.com/RobertCajun/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/285092-robertcajun/",
+    "title": "RobertCajun's Repository",
+    "index": 672
+  },
+  {
+    "url": "https://github.com/RoBro92/fanbridge-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/290531-robro92/",
+    "title": "RoBro92's Repository",
+    "index": 673
+  },
+  {
+    "url": "https://github.com/roflcoopter/viseron-unraid-ca-template",
+    "profile": "https://forums.unraid.net/profile/113120-roflcoopter",
+    "title": "roflcoopter's Repository",
+    "index": 674
+  },
+  {
+    "url": "https://github.com/kennethprose/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/174044-roseatoni/",
+    "title": "roseatoni's Repository",
+    "index": 675
+  },
+  {
+    "url": "https://github.com/cloud-fs/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/261359-rotten-pagoda5238/",
+    "title": "rotten-pagoda5238's Repository",
+    "index": 676
+  },
+  {
+    "url": "https://github.com/rohit-purandare/ShelfBridge-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/283015-rpurandare/",
+    "title": "rpurandare's Repository",
+    "index": 677
+  },
+  {
+    "url": "https://github.com/Saetron/unRAID-CA-templates",
+    "profile": "https://forums.unraid.net/profile/290584-saetron/",
+    "title": "saetron's Repository",
+    "index": 678
+  },
+  {
+    "url": "https://github.com/czerus/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/277784-sajnti/",
+    "title": "sajnti's Repository",
+    "index": 679
+  },
+  {
+    "url": "https://github.com/SAL-e/docker-templates",
+    "profile": "https://forums.unraid.net/profile/11345-sal-e/",
+    "title": "SAL-e's Repository",
+    "index": 680
+  },
+  {
+    "url": "https://github.com/sam10155/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/116626-sam10155/",
+    "title": "sam10155's Repository",
+    "index": 681
+  },
+  {
+    "url": "https://github.com/SamTV12345/podfetch-unraid-config",
+    "profile": "https://forums.unraid.net/profile/261451-samtv12345/",
+    "title": "SamTV12345's Repository",
+    "index": 682
+  },
+  {
+    "url": "https://github.com/kroeberd/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/291694-sarcasm/",
+    "title": "sarcasm's Repository",
+    "index": 683
+  },
+  {
+    "url": "https://github.com/SasaKaranovic/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/273010-sasakaranovic/",
+    "title": "SasaKaranovic's Repository",
+    "index": 684
+  },
+  {
+    "url": "https://github.com/SavageAUS/Unraid-Templates",
+    "profile": "https://forums.unraid.net/profile/91260-savageaus/",
+    "title": "SaveageAUS' Repository",
+    "index": 685
+  },
+  {
+    "url": "https://github.com/sebastienvermeille/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/122183-sbeex/",
+    "title": "sbeex's Repository",
+    "index": 686
+  },
+  {
+    "url": "https://github.com/scolcipitato/plugin-repository",
+    "profile": "https://forums.unraid.net/profile/109953-scolcipitato/",
+    "title": "scolcipitato's Repository",
+    "index": 687
+  },
+  {
+    "url": "https://github.com/SuFxGIT/scoutarr",
+    "profile": "https://forums.unraid.net/profile/293114-sufxur/",
+    "title": "Scoutarr's Repository",
+    "index": 688
+  },
+  {
+    "url": "https://github.com/Berrysekk/Script-Dashboard",
+    "profile": null,
+    "title": "Script Dashboard",
+    "index": 689
+  },
+  {
+    "url": "https://github.com/SCUR0/Unraid_Docker_Locust",
+    "profile": "https://forums.unraid.net/profile/274107-scuro/",
+    "title": "Scuro's Repository",
+    "index": 690
+  },
+  {
+    "url": "https://github.com/sdesbure/docker-containers",
+    "profile": "https://forums.unraid.net/profile/3477-sdesbure/",
+    "title": "sdesbure's Repository",
+    "index": 691
+  },
+  {
+    "url": "https://github.com/KodCloud-dev/unraid_template",
+    "profile": "https://forums.unraid.net/profile/255377-sealnado/",
+    "title": "sealnado's Repository",
+    "index": 692
+  },
+  {
+    "url": "https://github.com/sebtech33/unRAID-Templates",
+    "profile": "https://forums.unraid.net/profile/98806-sebtech33/",
+    "title": "SebTech33's Repository",
+    "index": 693
+  },
+  {
+    "url": "https://github.com/secretlycarl/onboarderr-unraid",
+    "profile": "https://forums.unraid.net/profile/289747-secretlycarl/",
+    "title": "SecretlyCarl's Repository",
+    "index": 694
+  },
+  {
+    "url": "https://github.com/dersimn/docker-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/11673-seim/",
+    "title": "seim's Repository",
+    "index": 695
+  },
+  {
+    "url": "https://github.com/sems/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/168805-sem/",
+    "title": "sem's Repository",
+    "index": 696
+  },
+  {
+    "url": "https://github.com/sftpmalin/Media-Remote-Convert",
+    "profile": null,
+    "title": "SftpMalin FFmpeg's Repository",
+    "index": 697
+  },
+  {
+    "url": "https://github.com/TheRealShadoh/babel",
+    "profile": "https://forums.unraid.net/profile/93754-shadoh/",
+    "title": "shadoh's Repository",
+    "index": 698
+  },
+  {
+    "url": "https://github.com/jakemoura/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/118681-jakemoura/",
+    "title": "shaksiwnl's Repository",
+    "index": 699
+  },
+  {
+    "url": "https://github.com/Shaneee/system-monitor",
+    "profile": "https://forums.unraid.net/profile/290974-shaneee92/",
+    "title": "Shaneee's Repository",
+    "index": 700
+  },
+  {
+    "url": "https://github.com/shrmnk/docker-templates",
+    "profile": "https://forums.unraid.net/profile/77786-shrmn/",
+    "title": "shrmn's Repository",
+    "index": 701
+  },
+  {
+    "url": "https://github.com/sidkapahi/curatarr",
+    "profile": "https://forums.unraid.net/profile/295114-sidkapahi/",
+    "title": "sidkapahi's Repository",
+    "index": 702
+  },
+  {
+    "url": "https://github.com/silman/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/163023-silman/",
+    "title": "silman's Repository",
+    "index": 703
+  },
+  {
+    "url": "https://github.com/SimonFair/unraid-plugins",
+    "profile": "https://forums.unraid.net/profile/75917-simonf",
+    "title": "SimonF's Repository",
+    "index": 704
+  },
+  {
+    "url": "https://github.com/GotAnAccount/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/187798-simpleserver/",
+    "title": "simpleServer's Repository",
+    "index": 705
+  },
+  {
+    "url": "https://github.com/simse/docker-templates",
+    "profile": "https://forums.unraid.net/profile/69400-simse/",
+    "title": "simse's Repository",
+    "index": 706
+  },
+  {
+    "url": "https://github.com/SiwatINC/unraid-ca-repository",
+    "profile": "https://forums.unraid.net/profile/72489-siwat2545/",
+    "title": "Siwat2545's Repository",
+    "index": 707
+  },
+  {
+    "url": "https://github.com/Skitals/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/97624-skitals/",
+    "title": "Skitals Repository",
+    "index": 708
+  },
+  {
+    "url": "https://github.com/SlrG/unRAID",
+    "profile": "https://forums.unraid.net/profile/16166-slrg/",
+    "title": "SlrG's Repository",
+    "index": 709
+  },
+  {
+    "url": "https://github.com/snapcrescent/templates",
+    "profile": "https://forums.unraid.net/profile/226383-navalgandhi1989/",
+    "title": "snapcrescent's Repository",
+    "index": 710
+  },
+  {
+    "url": "https://github.com/devdems/unraid",
+    "profile": "https://forums.unraid.net/profile/26537-snoopy86/",
+    "title": "snoopy86's Repository",
+    "index": 711
+  },
+  {
+    "url": "https://github.com/snuffomega/docker_unraid_templates",
+    "profile": "https://forums.unraid.net/profile/258583-snuffomega/",
+    "title": "snuffomega's Repository",
+    "index": 712
+  },
+  {
+    "url": "https://github.com/SnuK87/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/285383-snuk/",
+    "title": "Snuk's Repository",
+    "index": 713
+  },
+  {
+    "url": "https://github.com/soultaco83/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/87407-soultaco83/",
+    "title": "soultaco83's Repository",
+    "index": 714
+  },
+  {
+    "url": "https://github.com/jamcalli/pulsarr-unraid-templates",
+    "profile": "https://forums.unraid.net/profile/286940-sp00ks/",
+    "title": "sp00ks' Repository",
+    "index": 715
+  },
+  {
+    "url": "https://github.com/SpaceinvaderOne/Docker-Templates-Unraid",
+    "profile": "https://forums.unraid.net/profile/67288-spaceinvaderone/",
+    "title": "SpaceInvaderOne's Repository",
+    "index": 716
+  },
+  {
+    "url": "https://github.com/spants/unraidtemplates",
+    "profile": "https://forums.unraid.net/profile/2148-spants/",
+    "title": "Spants' Repository",
+    "index": 717
+  },
+  {
+    "url": "https://github.com/Spikhalskiy/docker-templates",
+    "profile": "https://forums.unraid.net/profile/82549-dmitry-spikhalskiy/",
+    "title": "Spikhalskiy's Repository",
+    "index": 718
+  },
+  {
+    "url": "https://github.com/Staffwerke/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/248178-staffwerke-gmbh/",
+    "title": "Staffwerke GmbH's Repository",
+    "index": 719
+  },
+  {
+    "url": "https://github.com/Steini1984/steini1984-s-repositoy",
+    "profile": "https://forums.unraid.net/profile/2957-steini84/",
+    "title": "steini84's Repository",
+    "index": 720
+  },
+  {
+    "url": "https://github.com/npmSteven/Unraid-VM-CP",
+    "profile": "https://forums.unraid.net/profile/102900-stevenrafferty/",
+    "title": "StevenRafferty's Repository",
+    "index": 721
+  },
+  {
+    "url": "https://github.com/storkenlorken/birdview",
+    "profile": null,
+    "title": "StorkenLorken's Repository",
+    "index": 722
+  },
+  {
+    "url": "https://github.com/bstottle/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/225-stottle/",
+    "title": "stottle's Repository",
+    "index": 723
+  },
+  {
+    "url": "https://github.com/strike84/DiskSpaceManagement-template",
+    "profile": "https://forums.unraid.net/profile/63311-strike/",
+    "title": "strike's Repository",
+    "index": 724
+  },
+  {
+    "url": "https://github.com/stuckless/unRAID",
+    "profile": "https://forums.unraid.net/profile/70058-stuckless/",
+    "title": "stuckless' Repository",
+    "index": 725
+  },
+  {
+    "url": "https://github.com/Sabreu/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/98837-sublivion/",
+    "title": "sublivion's Repository",
+    "index": 726
+  },
+  {
+    "url": "https://github.com/suitux/tagr-unraid",
+    "profile": "https://forums.unraid.net/profile/294950-suitux/",
+    "title": "suitux's Repository",
+    "index": 727
+  },
+  {
+    "url": "https://github.com/skrashevich/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/198957-svk/",
+    "icon": "https://avatars.githubusercontent.com/u/15078499?v=4",
+    "WebPage": "https://github.com/skrashevich",
+    "title": "svk's Repository",
+    "index": 728
+  },
+  {
+    "url": "https://github.com/sworcery/mem-zero",
+    "profile": null,
+    "title": "sworcery's 2nd Repository",
+    "index": 729
+  },
+  {
+    "url": "https://github.com/sworcery/ChannelHoarder",
+    "profile": "https://forums.unraid.net/profile/99321-sworcery/",
+    "title": "sworcery's Repository",
+    "index": 730
+  },
+  {
+    "url": "https://github.com/maxcerny/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/93919-sysco/",
+    "title": "sysco's Repository",
+    "index": 731
+  },
+  {
+    "url": "https://github.com/T4s3rF4c3/macreplay_v2",
+    "profile": "https://forums.unraid.net/profile/150938-t4s3rf4c3/",
+    "title": "T4s3rF4c3's Repository",
+    "index": 732
+  },
+  {
+    "url": "https://github.com/tajniak81/unraid-docker-templates",
+    "profile": "https://forums.unraid.net/profile/98215-tajniak81/",
+    "title": "Tajniak81's Repository",
+    "index": 733
+  },
+  {
+    "url": "https://github.com/kuroki-kael/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/283413-tatseo/",
+    "title": "tatseo's Repository",
+    "index": 734
+  },
+  {
+    "url": "https://github.com/Tautulli/Tautulli-Unraid-Template",
+    "profile": "https://forums.unraid.net/profile/69064-wreave/",
+    "title": "Tautulli's Repository",
+    "index": 735
+  },
+  {
+    "url": "https://github.com/schartrand77/makerworks-unraid-templates",
+    "profile": null,
+    "title": "techpunk's repo",
+    "index": 736
+  },
+  {
+    "url": "https://github.com/softerfish/seekandwatch",
+    "profile": "https://forums.unraid.net/profile/283725-tenletters/",
+    "title": "tenletter's Repository",
+    "index": 737
+  },
+  {
+    "url": "https://github.com/Terebi42/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/252870-terebi/",
+    "title": "Terebi's Repository",
+    "index": 738
+  },
+  {
+    "url": "https://github.com/testdasi/testdasi-unraid-repo",
+    "profile": "https://forums.unraid.net/profile/70144-testdasi",
+    "title": "testdasi's Repository",
+    "index": 739
+  },
+  {
+    "url": "https://github.com/jl94x4/ColleXions-WebUI",
+    "profile": "https://forums.unraid.net/profile/270097-thatja/",
+    "title": "thatja's Repository",
+    "index": 740
+  },
+  {
+    "url": "https://github.com/THESHULK/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/237924-the_shulk/",
+    "title": "THE_SHULK's Repository",
+    "index": 741
+  },
+  {
+    "url": "https://github.com/thedinz/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/145818-thedinz/",
+    "title": "thedinz' Repository",
+    "index": 742
+  },
+  {
+    "url": "https://github.com/theimmortal68/zappiti-server-docker",
+    "profile": "https://forums.unraid.net/profile/67130-theimmortal/",
+    "title": "theimmortal's Repository",
+    "index": 743
+  },
+  {
+    "url": "https://github.com/jlightner86/jellylooter",
+    "profile": "https://forums.unraid.net/profile/287631-thepizzaninja86/",
+    "title": "ThePizzaNinja86's Repository",
+    "index": 744
+  },
+  {
+    "url": "https://github.com/Th0masDB/unraid_template",
+    "profile": "https://forums.unraid.net/profile/126905-thomasdb__/",
+    "title": "ThomasDB's Repository",
+    "index": 745
+  },
+  {
+    "url": "https://github.com/tynor88/docker-templates",
+    "profile": "https://forums.unraid.net/profile/70206-thomast_88/",
+    "title": "thomast_88's Repository",
+    "index": 746
+  },
+  {
+    "url": "https://github.com/Thraxis/docker-templates",
+    "profile": "https://forums.unraid.net/profile/9802-thraxis/",
+    "title": "Thraxis' Repository",
+    "index": 747
+  },
+  {
+    "url": "https://github.com/timstephens24/docker-templates",
+    "profile": "https://forums.unraid.net/profile/67918-timstephens24/",
+    "title": "timstephens24's Repository",
+    "index": 748
+  },
+  {
+    "url": "https://github.com/tinglis1/docker-containers",
+    "profile": "https://forums.unraid.net/profile/6492-tinglis1/",
+    "title": "tinglis1's Repository",
+    "index": 749
+  },
+  {
+    "url": "https://github.com/tombowditch/docker-templates",
+    "profile": "https://forums.unraid.net/profile/80184-tombowditch/",
+    "title": "tombowditch's Repository",
+    "index": 750
+  },
+  {
+    "url": "https://github.com/T-Eberle/unraid-community-apps",
+    "profile": "https://forums.unraid.net/profile/289970-tommy_e/",
+    "title": "Tommy_E's Repository",
+    "index": 751
+  },
+  {
+    "url": "https://github.com/tommyvange/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/282469-tommyvange/",
+    "title": "tommyvange's Repository",
+    "index": 752
+  },
+  {
+    "url": "https://github.com/tophat17/jelly-request",
+    "profile": "https://forums.unraid.net/profile/172432-tophat17/",
+    "title": "TopHat17's Repository",
+    "index": 753
+  },
+  {
+    "url": "https://github.com/tritones/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/172136-tritones/",
+    "title": "tritones' Repository",
+    "index": 754
+  },
+  {
+    "url": "https://github.com/TrophyBuck/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/140258-trophybuck/",
+    "title": "TrophyBuck's Repository",
+    "index": 755
+  },
+  {
+    "url": "https://github.com/tschoerk/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/273668-tschoerk/",
+    "title": "tschoerk's Repository",
+    "index": 756
+  },
+  {
+    "url": "https://github.com/Twingate-Community/unraid-template",
+    "profile": "https://forums.unraid.net/profile/289418-twingate-andrewb/",
+    "title": "Twingate Community's Repository",
+    "index": 757
+  },
+  {
+    "url": "https://github.com/NicolasHaas/unraid-xml-templates",
+    "profile": "https://forums.unraid.net/profile/110262-twixii/",
+    "title": "Twixii's Repository",
+    "index": 758
+  },
+  {
+    "url": "https://github.com/Tylan/Unraid",
+    "profile": null,
+    "title": "Tylan's Repository",
+    "index": 759
+  },
+  {
+    "url": "https://github.com/type0dev/Unraid-Template",
+    "profile": "https://forums.unraid.net/profile/275726-type0dev/",
+    "title": "type0dev's Repository",
+    "index": 760
+  },
+  {
+    "url": "https://github.com/TypingPenguin/docker-templates",
+    "profile": "https://forums.unraid.net/profile/283235-typingpenguin/",
+    "title": "TypingPenguin's Repository",
+    "index": 761
+  },
+  {
+    "url": "https://github.com/charlescng/docker-containers",
+    "profile": "https://forums.unraid.net/profile/64811-uberchuckie/",
+    "title": "uberchuckie's Repository",
+    "index": 762
+  },
+  {
+    "url": "https://github.com/BabaBooey84/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/7743-uderzo/",
+    "title": "Uderzo's Repository",
+    "index": 763
+  },
+  {
+    "url": "https://github.com/Poag/docker-xml",
+    "profile": "https://forums.unraid.net/profile/63933-uirel/",
+    "title": "Uirel's Repository",
+    "index": 764
+  },
+  {
+    "url": "https://github.com/Ulisses1478/templates-unraid",
+    "profile": "https://forums.unraid.net/profile/90485-ulisses1478/",
+    "title": "ulisses1478's Repository",
+    "index": 765
+  },
+  {
+    "url": "https://github.com/undead-reaper/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
+    "title": "Undead Reaper's Repository",
+    "index": 766
+  },
+  {
+    "url": "https://github.com/Unlearned6688/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/170061-unjustice/",
+    "title": "UnJustice's Repository",
+    "index": 767
+  },
+  {
+    "url": "https://github.com/zip-fa/unraid-torrserver",
+    "profile": "https://forums.unraid.net/profile/280443-unraidnewbie2211/",
+    "title": "UnraidNewbie2211's Repository",
+    "index": 768
+  },
+  {
+    "url": "https://github.com/untraceablez/uvdesk-unraid",
+    "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
+    "title": "untraceablez' Repository",
+    "index": 769
+  },
+  {
+    "url": "https://github.com/untraceablez/unraid-apps/",
+    "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
+    "title": "untraceablez's Repository",
+    "index": 770
+  },
+  {
+    "url": "https://github.com/UnToobed/Unraid-Docker-Templates",
+    "profile": "https://forums.unraid.net/profile/160182-unusmundus/",
+    "title": "UnusMundus' Repository",
+    "index": 771
+  },
+  {
+    "url": "https://github.com/sbondCo/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/274118-unwieldy_dingy/",
+    "title": "unwieldy_dingy's Repository",
+    "index": 772
+  },
+  {
+    "url": "https://github.com/GHJJ123/brainrotguard",
+    "profile": "https://forums.unraid.net/profile/100435-ur-jay/",
+    "title": "UR-jay's Repository",
+    "index": 773
+  },
+  {
+    "url": "https://github.com/vwdewaal/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/145081-vannie78/",
+    "title": "vannie78's Repository",
+    "index": 774
+  },
+  {
+    "url": "https://github.com/vanshady/unraid-templates",
+    "profile": null,
+    "title": "vanshady's Repository",
+    "index": 775
+  },
+  {
+    "url": "https://github.com/Vilhjalmr26/unraid_templates",
+    "profile": "https://forums.unraid.net/profile/126802-vilhjalmr/",
+    "title": "Vilhjalmr's Repository",
+    "index": 776
+  },
+  {
+    "url": "https://github.com/vincentmakes/cv-manager",
+    "profile": "https://forums.unraid.net/profile/292228-vincentmakes/",
+    "title": "vincentmakes' Repository",
+    "index": 777
+  },
+  {
+    "url": "https://github.com/vLX42/backdrop-generator",
+    "profile": "https://forums.unraid.net/profile/288463-vlx42/",
+    "title": "vlx42's Repository",
+    "index": 778
+  },
+  {
+    "url": "https://github.com/taha-yassine/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/248389-vodros/",
+    "title": "Vodros' Repository",
+    "index": 779
+  },
+  {
+    "url": "https://github.com/vonhex/unraid-templates",
+    "profile": null,
+    "title": "Vonhex's Repository",
+    "index": 780
+  },
+  {
+    "url": "https://github.com/waazaa-fr/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/132702-waazaa/",
+    "title": "waazaa's Repository",
+    "index": 781
+  },
+  {
+    "url": "https://github.com/WaffleMaster22/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/278326-waffle22/",
+    "title": "Waffle22's Repository",
+    "index": 782
+  },
+  {
+    "url": "https://github.com/warieon/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/240351-warieon/",
+    "title": "warieon's Repository",
+    "index": 783
+  },
+  {
+    "url": "https://github.com/SuFxGIT/whatseerr",
+    "profile": "https://forums.unraid.net/profile/293114-sufxur/",
+    "title": "Whatseerr's Repository",
+    "index": 784
+  },
+  {
+    "url": "https://github.com/WhydahGally/docker-templates",
+    "profile": null,
+    "title": "WhydahGally's Repository",
+    "index": 785
+  },
+  {
+    "url": "https://github.com/Receipt-Wrangler/receipt-wrangler-unraid",
+    "profile": "https://forums.unraid.net/profile/268018-wrangler/",
+    "title": "wrangler's Repository",
+    "index": 786
+  },
+  {
+    "url": "https://github.com/WuSiYu/unraid-ca-xml/",
+    "profile": "https://forums.unraid.net/profile/175574-wu23333/",
+    "title": "Wu23333's Repository",
+    "index": 787
+  },
+  {
+    "url": "https://github.com/xavier-hernandez/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/158924-xavierh/",
+    "title": "xavierh's Repository",
+    "index": 788
+  },
+  {
+    "url": "https://github.com/alexphillips-dev/unraid-ca-templates",
+    "profile": "https://forums.unraid.net/profile/122915-xcrownedclownsx/",
+    "title": "XCrownedClownsX's Repository",
+    "index": 789
+  },
+  {
+    "url": "https://github.com/xenco/docker-templates",
+    "profile": "https://forums.unraid.net/profile/155847-xenco/",
+    "title": "xenco's Repository",
+    "index": 790
+  },
+  {
+    "url": "https://github.com/XeXSolutions/unraid-stats",
+    "profile": "https://forums.unraid.net/profile/165045-xexsolutions/",
+    "title": "XeXSolutions' Repository",
+    "index": 791
+  },
+  {
+    "url": "https://github.com/xiaodoudou/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/145775-xiaodoudou/",
+    "title": "Xiaodoudou's Repository",
+    "index": 792
+  },
+  {
+    "url": "https://github.com/xompage/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/262898-xompage/",
+    "title": "xompage's Repository",
+    "index": 793
+  },
+  {
+    "url": "https://github.com/xxBeanSproutxx/unraid-docling-ca",
+    "profile": "https://forums.unraid.net/profile/288925-bean_sprout/",
+    "title": "xxBeanSproutxx's Repository",
+    "index": 794
+  },
+  {
+    "url": "https://github.com/valaypatel/unraidapps",
+    "profile": "https://forums.unraid.net/profile/120399-yoda/",
+    "title": "Yoda's Repository",
+    "index": 795
+  },
+  {
+    "url": "https://github.com/cslemieux/unraid-plugin-templates",
+    "profile": "https://forums.unraid.net/profile/98934-zapbranagann/",
+    "title": "zapbranagann's Repository",
+    "index": 796
+  },
+  {
+    "url": "https://github.com/caddickzac/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/293796-zcaddick/",
+    "title": "zcaddick's Repository",
+    "index": 797
+  },
+  {
+    "url": "https://github.com/Zggis/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/118712-zggis/",
+    "title": "Zggis' Repository",
+    "index": 798
+  },
+  {
+    "url": "https://github.com/JZomDev/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/159615-zguilt/",
+    "title": "zguilt's Repository",
+    "index": 799
+  },
+  {
+    "url": "https://github.com/zhtengw/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/245393-zhtengw/",
+    "title": "zhtengw's Repository",
+    "index": 800
+  },
+  {
+    "url": "https://github.com/Zuerrex/unraid-templates",
+    "profile": "https://forums.unraid.net/profile/234570-zuerrex/",
+    "title": "zuerrex's Repository",
+    "index": 801
+  },
+  {
+    "url": "https://github.com/zyphermonkey/docker-templates",
+    "profile": "https://forums.unraid.net/profile/67871-zyphermonkey/",
+    "title": "zyphermonkey's Repository",
+    "index": 802
+  },
+  {
+    "url": "https://github.com/CrazyDevil66/braincut-blur",
+    "profile": "https://github.com/CrazyDevil66",
+    "bio": "Self-hosted automation tools for Unraid. Creator of BrainCut \u2013 an n8n-based video processing pipeline with Telegram control.",
+    "icon": "https://avatars.githubusercontent.com/u/24143496?v=4",
+    "DonateLink": "",
+    "DonateText": "",
+    "title": "CrazyDevil66's Repository",
+    "index": 803
+  }
 ]


### PR DESCRIPTION
Adding CrazyDevil66's repository to the AppFeed.

**Template:** [braincut-blur](https://github.com/CrazyDevil66/braincut-blur)
**Description:** BrainCut Blur Service – Docker container for automatic face blurring in videos, used by the BrainCut n8n workflow.

Template URL: https://raw.githubusercontent.com/CrazyDevil66/braincut-blur/main/unraid-template.xml